### PR TITLE
Faster compiled generation concatenation

### DIFF
--- a/models/llama/model.py
+++ b/models/llama/model.py
@@ -234,9 +234,9 @@ class LLaMA(nn.Module):
         idx = empty
 
         # generate max_new_tokens tokens
-        for i in range(T, T_new):
+        for t in range(T, T_new):
             # ignore the not-filled-yet tokens
-            idx_cond = idx[:, :i]
+            idx_cond = idx[:, :t]
             # if the sequence context is growing too long we must crop it at max_seq_length
             idx_cond = idx_cond if T <= self.params.max_seq_length else idx_cond[:, -self.params.max_seq_length:]
 
@@ -251,6 +251,6 @@ class LLaMA(nn.Module):
 
             probs = F.softmax(logits, dim=-1)
             idx_next = torch.multinomial(probs, num_samples=1)
-            idx[:, i] = idx_next
+            idx[:, t] = idx_next
 
         return idx


### PR DESCRIPTION
~~`torch.cat` is slow when the model is compiled.~~ edit: not the case when randint is not used.

With no sequential dependency
```python
import time

import torch

torch.set_float32_matmul_precision("high")


def bench(f, name=None, iters=100, warmup=5, display=True):
    for _ in range(warmup):
        f()
    torch.cuda.synchronize()
    begin = time.time()
    for _ in range(iters):
        f()
    torch.cuda.synchronize()
    us_per_iter = (time.time() - begin) * 1e6 / iters
    if name is None:
        res = us_per_iter
    else:
        res = f"{name}: {us_per_iter}us"
    if display:
        print(res)
    return res


B = 16
T = 1024
max_new_tokens = 1024
device = torch.device("cuda")


def get_inputs():
    idx = torch.randint(low=1, high=100, size=(B, T), device=device)
    idx2 = idx.clone()
    return idx, idx2


def cat(idx, max_new_tokens):
    for _ in range(max_new_tokens):
        # simulate token generation
        idx_next = torch.randint(low=0, high=100, size=(B, 1), device=idx.device)
        idx = torch.cat((idx, idx_next), dim=1)
    return idx


def fill(idx, max_new_tokens):
    B, T = idx.shape
    T_new = T + max_new_tokens
    device = idx.device
    out = torch.empty(B, T_new, dtype=idx.dtype, device=device)
    out[:, :T] = idx
    for i in range(T, T_new):
        # simulate token generation
        idx_next = torch.randint(low=0, high=100, size=(B,), device=device)
        out[:, i] = idx_next
    return out


idx, idx2 = get_inputs()
torch.manual_seed(123)
cat_res = cat(idx, 10)
torch.manual_seed(123)
fill_res = fill(idx2, 10)
torch.testing.assert_close(cat_res, fill_res)
print("Implementations match")

idx, idx2 = get_inputs()
compiled_cat = torch.compile(cat)
bench(lambda: cat(idx, max_new_tokens), name="cat eager")
bench(lambda: compiled_cat(idx2, max_new_tokens), name="cat dynamo")

idx, idx2 = get_inputs()
compiled_fill = torch.compile(fill)
bench(lambda: fill(idx, max_new_tokens), name="fill eager")
bench(lambda: compiled_fill(idx2, max_new_tokens), name="fill dynamo")
```

```python
Implementations match
cat eager: 20704.336166381836us
cat dynamo: 55293.88189315796us
fill eager: 21523.330211639404us
fill dynamo: 15636.956691741943us
```

The workload is completely dispatcher-bound than compute-bound.
"cat dynamo" is slower because each iteration randint is launching an expensive triton kernel.
 
With sequential dependency (limits horizontal fusion potential)
```python
import time

import torch

torch.set_float32_matmul_precision("high")


def bench(f, name=None, iters=100, warmup=5, display=True):
    for _ in range(warmup):
        f()
    torch.cuda.synchronize()
    begin = time.time()
    for _ in range(iters):
        f()
    torch.cuda.synchronize()
    us_per_iter = (time.time() - begin) * 1e6 / iters
    if name is None:
        res = us_per_iter
    else:
        res = f"{name}: {us_per_iter}us"
    if display:
        print(res)
    return res


B = 16
T = 1024
max_new_tokens = 1024
device = torch.device("cuda")


def get_inputs():
    idx = torch.randint(low=1, high=100, size=(B, T), device=device)
    idx2 = idx.clone()
    return idx, idx2


def cat(idx, max_new_tokens):
    for _ in range(max_new_tokens):
        # simulate token generation
        idx_next = torch.sum(idx, dim=1, keepdim=True)
        idx = torch.cat((idx, idx_next), dim=1)
    return idx


def fill(idx, max_new_tokens):
    B, T = idx.shape
    T_new = T + max_new_tokens
    device = idx.device
    out = torch.empty(B, T_new, dtype=idx.dtype, device=device)
    out[:, :T] = idx
    idx = out
    for i in range(T, T_new):
        idx_cond = idx[:, :i]
        # simulate token generation
        idx_next = torch.sum(idx_cond, dim=1)
        idx[:, i] = idx_next
    return idx


idx, idx2 = get_inputs()
torch.manual_seed(123)
cat_res = cat(idx, 10)
torch.manual_seed(123)
fill_res = fill(idx2, 10)
torch.testing.assert_close(cat_res, fill_res)
print("Implementations match")

idx, idx2 = get_inputs()
compiled_cat = torch.compile(cat)
bench(lambda: cat(idx, max_new_tokens), name="cat eager")
bench(lambda: compiled_cat(idx2, max_new_tokens), name="cat dynamo")

idx, idx2 = get_inputs()
compiled_fill = torch.compile(fill)
bench(lambda: fill(idx, max_new_tokens), name="fill eager")
bench(lambda: compiled_fill(idx2, max_new_tokens), name="fill dynamo")
```

```python
Implementations match
cat eager: 18855.52167892456us
cat dynamo: 19448.78578186035us
fill eager: 25298.51198196411us
fill dynamo: 11076.452732086182us
```

