### PR TITLE
Cache pip dependencies in CPU tests

### DIFF
--- a/.github/workflows/cpu-tests.yml
+++ b/.github/workflows/cpu-tests.yml
@@ -40,8 +40,6 @@ jobs:
 
     - name: Run tests without the package installed
       run: |
-        pip list
-        pip uninstall -y lit-llama
         pip install pytest -r requirements.txt
         pip list
 

--- a/.github/workflows/cpu-tests.yml
+++ b/.github/workflows/cpu-tests.yml
@@ -40,13 +40,6 @@ jobs:
 
     - name: Install dependencies
       run: |
-<<<<<<< Updated upstream
-        pip install pytest . -r requirements.txt
-        pip list
-
-    - name: Run tests
-      run: |
-=======
         pip list
         pip uninstall -y .
         pip install pytest -r requirements.txt
@@ -59,5 +52,4 @@ jobs:
         pip install . --no-deps
         pip list
 
->>>>>>> Stashed changes
         pytest -v --durations=10 --disable-pytest-warnings --strict-markers

--- a/.github/workflows/cpu-tests.yml
+++ b/.github/workflows/cpu-tests.yml
@@ -33,12 +33,31 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+        cache-dependency-path: |
+          requirements.txt
+          setup.py
 
     - name: Install dependencies
       run: |
+<<<<<<< Updated upstream
         pip install pytest . -r requirements.txt
         pip list
 
     - name: Run tests
       run: |
+=======
+        pip list
+        pip uninstall -y .
+        pip install pytest -r requirements.txt
+        pip list
+
+        pytest --disable-pytest-warnings --strict-markers
+
+    - name: Run tests
+      run: |
+        pip install . --no-deps
+        pip list
+
+>>>>>>> Stashed changes
         pytest -v --durations=10 --disable-pytest-warnings --strict-markers

--- a/.github/workflows/cpu-tests.yml
+++ b/.github/workflows/cpu-tests.yml
@@ -50,6 +50,5 @@ jobs:
     - name: Run tests
       run: |
         pip install . --no-deps
-        pip list
 
         pytest -v --durations=10 --disable-pytest-warnings --strict-markers

--- a/.github/workflows/cpu-tests.yml
+++ b/.github/workflows/cpu-tests.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Run tests without the package installed
       run: |
         pip list
-        pip uninstall -y .
+        pip uninstall -y lit-llama
         pip install pytest -r requirements.txt
         pip list
 


### PR DESCRIPTION
Installing dependencies takes way longer than our tests. This adds a cache for them