### PR TITLE
Save checkpoint in train.py

### DIFF
--- a/lit_llama/utils.py
+++ b/lit_llama/utils.py
@@ -1,0 +1,22 @@
+"""Utility functions for training and inference."""
+
+import torch
+from lightning.fabric.strategies import FSDPStrategy
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+from torch.distributed.fsdp import StateDictType, FullStateDictConfig
+
+
+def save_model_checkpoint(fabric, model, file_path):
+    """Handles boilerplate logic for retrieving and saving the state_dict."""
+
+    if isinstance(fabric.strategy, FSDPStrategy):
+        save_policy = FullStateDictConfig(offload_to_cpu=True, rank0_only=True)
+        with FSDP.state_dict_type(model, StateDictType.FULL_STATE_DICT, save_policy):
+            state_dict = model._forward_module.state_dict()
+    
+    else:
+        state_dict = model.state_dict()
+
+    if fabric.global_rank == 0:
+        torch.save(state_dict, file_path)
+    fabric.barrier()

--- a/lit_llama/utils.py
+++ b/lit_llama/utils.py
@@ -7,7 +7,10 @@ from torch.distributed.fsdp import StateDictType, FullStateDictConfig
 
 
 def save_model_checkpoint(fabric, model, file_path):
-    """Handles boilerplate logic for retrieving and saving the state_dict."""
+    """Handles boilerplate logic for retrieving and saving the state_dict.
+    
+    This will be upstreamed to Fabric soon.
+    """
 
     if isinstance(fabric.strategy, FSDPStrategy):
         save_policy = FullStateDictConfig(offload_to_cpu=True, rank0_only=True)

--- a/lit_llama/utils.py
+++ b/lit_llama/utils.py
@@ -13,7 +13,6 @@ def save_model_checkpoint(fabric, model, file_path):
         save_policy = FullStateDictConfig(offload_to_cpu=True, rank0_only=True)
         with FSDP.state_dict_type(model, StateDictType.FULL_STATE_DICT, save_policy):
             state_dict = model._forward_module.state_dict()
-    
     else:
         state_dict = model.state_dict()
 

--- a/train.py
+++ b/train.py
@@ -18,8 +18,8 @@ import numpy as np
 
 from lit_llama.model import Block, LLaMA, LLaMAConfig
 
-out_dir = "out"
-eval_interval = 2000
+out_dir = "out/fsdp-chkpt"
+eval_interval = 10
 eval_iters = 200
 log_interval = 1
 # compilation fails as it does not support torch.complex64 for RoPE
@@ -55,7 +55,7 @@ def main() -> None:
     config.block_size = block_size
     config.vocab_size = 100  # from prepare_shakespeare.py
 
-    with fabric.device:
+    with fabric.device, fabric.sharded_model():
         model = LLaMA(config)
 
     # if compile:
@@ -87,12 +87,21 @@ def train(
         # TODO: add learning rate scheduling
 
         # evaluate the loss on train/val sets and write checkpoints
-        if iter_num > 0 and iter_num % eval_interval == 0 and fabric.global_rank == 0:
+        if iter_num % eval_interval == 0:
             val_loss = validate(fabric, model, val_data)
             fabric.print(f"step {iter_num}: val loss {val_loss:.4f}")
-            # TODO: Save with Fabric
-            # print(f"saving checkpoint to {out_dir}")
-            # torch.save(checkpoint, os.path.join(out_dir, 'ckpt.pt'))
+
+            # TODO: Update this to `fabric.save()` once it supports FSDP checkpointing
+            from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+            from torch.distributed.fsdp import StateDictType, FullStateDictConfig
+            
+            save_policy = FullStateDictConfig(offload_to_cpu=True)
+            with FSDP.state_dict_type(model, StateDictType.LOCAL_STATE_DICT, save_policy):
+                state_dict = model._forward_module.state_dict()
+            if fabric.global_rank == 0:
+                print(f"Saving checkpoint to {out_dir}")
+                torch.save(state_dict, os.path.join(out_dir, "ckpt.pt"))
+            fabric.barrier()
 
         t0 = time.time()
 

--- a/train.py
+++ b/train.py
@@ -18,7 +18,7 @@ import numpy as np
 
 from lit_llama.model import Block, LLaMA, LLaMAConfig
 
-out_dir = "out/fsdp-chkpt"
+out_dir = "out/training"
 eval_interval = 2000
 eval_iters = 200
 log_interval = 1
@@ -55,7 +55,7 @@ def main() -> None:
     config.block_size = block_size
     config.vocab_size = 100  # from prepare_shakespeare.py
 
-    with fabric.device, fabric.sharded_model():
+    with fabric.device:
         model = LLaMA(config)
 
     # if compile:


### PR DESCRIPTION
Adds saving in train.py. The full consolidated checkpoint gets saved so it can be loaded into single-gpu inference. This won't work for the larger models. This is only temporary until Fabric supports saving and loading with FSDP. 

Note: If we don't like the boilerplate this adds to train.py, we can also hold off merging this and instead wait for Fabric to address this in general.

Fixes #88

