### PR TITLE
GPTQ int4 quantization

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,14 +104,22 @@ This will run the 7B model and require ~26 GB of GPU memory (A100 GPU).
 
 ### Run Lit-LLaMA on consumer devices
 
-For GPUs with less memory, enable quantization (`--quantize true`) or use bfloat16 (`--dtype bfloat16`). Quantization will take longer to load but require ~8GB of memory. bfloat16 is closer to the "full deal" and runs on ~10GB of GPU memory.
+For GPUs with less memory, enable quantization (`--quantize llm.int8`) or use bfloat16 (`--dtype bfloat16`). Quantization will take longer to load but require ~8GB of memory. bfloat16 is closer to the "full deal" and runs on ~10GB of GPU memory.
 This can run on any consumer GPU.
 
 ```bash
-python generate.py --quantize true --prompt "Hello, my name is"
+python generate.py --quantize llm.int8 --prompt "Hello, my name is"
 ```
 
 See `python generate.py --help` for more options.
+
+You can also use GPTQ-style int4 quantization, but this needs conversions of the weights first:
+
+```bash
+python quantize.py --checkpoint_path state_dict.pth --tokenizer_path tokenizer.model --output_path llama-7b-gptq.4bit.pt --dtype bfloat16  --quantize gptq.int4
+```
+
+With the generated quantized checkpoint generation works as usual with `--quantize gptq.int4`, bringing GPU usage to about ~5GB. As only the weights of the Linear layers are quantized, it is useful to use `--dtype bfloat16` even with the quantization enabled.
 
 &nbsp;
 
@@ -163,6 +171,7 @@ Don't forget to [join our Discord](https://discord.gg/VptPCZkGNa)!
 - [@FacebookResearch](https://github.com/facebookresearch) for the original [LLaMA implementation](https://github.com/facebookresearch/llama)
 - [@TimDettmers](https://github.com/TimDettmers) for [bitsandbytes](https://github.com/TimDettmers/bitsandbytes)
 - [@Microsoft](https://github.com/microsoft) for [LoRA](https://github.com/microsoft/LoRA)
+- [@IST-DASLab](https://github.com/IST-DASLab) for [GPTQ](https://github.com/IST-DASLab/gptq)
 
 ## License
 

--- a/generate.py
+++ b/generate.py
@@ -6,7 +6,7 @@ from typing import Optional
 import lightning as L
 import torch
 
-from lit_llama import LLaMA, Tokenizer, as_8_bit_quantized
+from lit_llama import LLaMA, Tokenizer
 from lit_llama.utils import EmptyInitOnDevice
 
 
@@ -77,7 +77,7 @@ def main(
     tokenizer_path: Optional[Path] = None,
     model_size: str = "7B",
     dtype: Optional[str] = None,
-    quantize: bool = False,
+    quantize: Optional[str] = None,
 ) -> None:
     """Generates text samples based on a pre-trained LLaMA model and tokenizer.
 
@@ -93,7 +93,9 @@ def main(
             ``"cpu"``, ``"cuda"``, ``"mps"``, ``"gpu"``, ``"tpu"``, ``"auto"``.
         checkpoint_path: The checkpoint path to load.
         tokenizer_path: The tokenizer path to load.
-        quantize: Whether to quantize the model using the `LLM.int8()` method
+        quantize: Whether to quantize the model and using which method:
+            ``"llm.int8"``: LLM.int8() mode,
+            ``"gptq.int4"``: GPTQ 4-bit mode.
     """
     if not checkpoint_path:
         checkpoint_path = Path(f"./checkpoints/lit-llama/{model_size}/state_dict.pth")
@@ -104,14 +106,15 @@ def main(
 
     fabric = L.Fabric(accelerator=accelerator, devices=1)
 
-    quantization_mode = 'llm.int8' if quantize else None
     if dtype is not None:
         dt = getattr(torch, dtype, None)
         if not isinstance(dt, torch.dtype):
             raise ValueError(f"{dtype} is not a valid dtype.")
         dtype = dt
 
-    with EmptyInitOnDevice(device=fabric.device, dtype=dtype, quantization_mode=quantization_mode):
+    with EmptyInitOnDevice(
+        device=fabric.device, dtype=dtype, quantization_mode=quantize
+    ):
         print("Loading model ...", file=sys.stderr)
         t0 = time.time()
         model = LLaMA.from_name(model_size)

--- a/lit_llama/__init__.py
+++ b/lit_llama/__init__.py
@@ -1,3 +1,2 @@
 from lit_llama.model import LLaMAConfig, LLaMA, RMSNorm, build_rope_cache, apply_rope
-from lit_llama.quantization import as_8_bit_quantized
 from lit_llama.tokenizer import Tokenizer

--- a/lit_llama/quantization.py
+++ b/lit_llama/quantization.py
@@ -1,6 +1,7 @@
 import os
 from contextlib import contextmanager
 import warnings
+import math
 
 import torch
 
@@ -14,60 +15,261 @@ warnings.filterwarnings(
     "ignore", 
     message="The installed version of bitsandbytes was compiled without GPU support. 8-bit optimizers and GPU quantization are unavailable."
 )
-import bitsandbytes as bnb  # noqa: E402
+
+try:
+    import bitsandbytes as bnb  # noqa: E402
+except:
+    bnb = None
+
+if bnb is not None:
+    class Linear8bitLt(bnb.nn.Linear8bitLt):
+        """Wraps `bnb.nn.Linear8bitLt` and enables instantiation directly on the device and
+        re-quantizaton when loading the state dict.
 
 
-class Linear8bitLt(bnb.nn.Linear8bitLt):
-    """Wraps `bnb.nn.Linear8bitLt` and enables instantiation directly on the device and
-    re-quantizaton when loading the state dict.
-    
-    
-    This should only be used for inference. For training, use `bnb.nn.Linear8bitLt` directly.
-    """
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs, has_fp16_weights=False, threshold=6.0)
-        # We quantize the initial weight here so we don't end up filling the device
-        # memory with float32 weights which could lead to OOM.
-        self._quantize_weight(self.weight.data)
+        This should only be used for inference. For training, use `bnb.nn.Linear8bitLt` directly.
+        """
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs, has_fp16_weights=False, threshold=6.0)
+            # We quantize the initial weight here so we don't end up filling the device
+            # memory with float32 weights which could lead to OOM.
+            self._quantize_weight(self.weight.data)
 
-    def _load_from_state_dict(self, local_state_dict, *args, **kwargs):
-        # There is only one key that ends with `*.weight`, the other one is the bias
-        weight_key = next(name for name in local_state_dict.keys() if name.endswith("weight"))
+        def _load_from_state_dict(self, local_state_dict, *args, **kwargs):
+            # There is only one key that ends with `*.weight`, the other one is the bias
+            weight_key = next(name for name in local_state_dict.keys() if name.endswith("weight"))
 
-        # Load the weight from the state dict and re-quantize it
-        weight = local_state_dict.pop(weight_key)
-        self._quantize_weight(weight)
+            # Load the weight from the state dict and re-quantize it
+            weight = local_state_dict.pop(weight_key)
+            self._quantize_weight(weight)
 
-        # If there is a bias, let nn.Module load it
-        if local_state_dict:
-            super()._load_from_state_dict(local_state_dict, *args, **kwargs)
-    
-    def _quantize_weight(self, weight: torch.Tensor) -> None:
-        # This code is taken and adapted from `bnb.nn.Int8Params.cuda()`
-        B = weight.contiguous().half().cuda()
-        CB, CBt, SCB, SCBt, coo_tensorB = bnb.functional.double_quant(B)
-        del CBt
-        del SCBt
-        self.weight.data = CB
-        setattr(self.weight, "CB", CB)
-        setattr(self.weight, "SCB", SCB)
+            # If there is a bias, let nn.Module load it
+            if local_state_dict:
+                super()._load_from_state_dict(local_state_dict, *args, **kwargs)
+
+        def _quantize_weight(self, weight: torch.Tensor) -> None:
+            # This code is taken and adapted from `bnb.nn.Int8Params.cuda()`
+            B = weight.contiguous().half().cuda()
+            CB, CBt, SCB, SCBt, coo_tensorB = bnb.functional.double_quant(B)
+            del CBt
+            del SCBt
+            self.weight.data = CB
+            setattr(self.weight, "CB", CB)
+            setattr(self.weight, "SCB", SCB)
 
 
-@contextmanager
-def as_8_bit_quantized(device: torch.device, enabled: bool = True):
-    """A context manager under which you can instantiate the model with 8-bit quantized tensors
-    being created directly on the given device.
-    """
+# for correctness but with terrible perf
+class ColBlockQuantizedLinear(torch.nn.Module):
+    def __init__(self, in_features, out_features, bias: bool, *, bits, tile_cols):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.tile_cols = tile_cols if tile_cols != -1 else self.in_features
+        self.bits = bits
+        self.entries_per_byte = 8 // bits
+        assert self.entries_per_byte > 0 and self.entries_per_byte * self.bits == 8
+        assert in_features % self.entries_per_byte == 0
+        self.register_buffer("quant_weight", torch.empty((self.out_features, self.in_features // self.entries_per_byte), dtype=torch.uint8))
+        self.register_buffer("scales", torch.empty((self.out_features, (self.in_features + self.tile_cols - 1) // self.tile_cols)))
+        self.register_buffer("zeros", torch.empty_like(self.scales))
+        assert isinstance(bias, bool)
+        if bias:
+            self.register_buffer("bias", torch.empty((self.out_features,)))
+        else:
+            self.register_buffer("bias", None)
 
-    with torch.device(device):
-        if not enabled:
-            yield
-            return
+    def pack_weight(self, weight):
+        weight = weight.to(device=self.quant_weight.device, copy=True)
+        for j in range(self.scales.size(1)):
+            weight[:, j * self.tile_cols: (j + 1) * self.tile_cols] /= self.scales[: , j: j+1]
+            weight[:, j * self.tile_cols: (j + 1) * self.tile_cols] += self.zeros[: , j: j+1]
+        weight = weight.clamp_(min=0, max=2 ** self.bits - 1).to(dtype=torch.uint8)
+        self.quant_weight.zero_()
+        for nr in range(self.entries_per_byte):
+            self.quant_weight += weight[:, nr::self.entries_per_byte] << (nr * self.bits)
 
-        if device.type != "cuda":
-            raise ValueError("Quantization is only supported on the GPU.")
+    def get_weight(self, dtype=torch.float):
+        weight = torch.empty((self.out_features, self.in_features),  device=self.quant_weight.device, dtype=dtype)
+        mask = (1<<self.bits) - 1
+        for nr in range(self.entries_per_byte):
+            weight[:, nr::self.entries_per_byte] = ((self.quant_weight >> (nr * self.bits)) & mask).float()
+        self.quant_weight.to(dtype)
+        for j in range(self.scales.size(1)):
+            weight[:, j * self.tile_cols: (j + 1) * self.tile_cols] -= self.zeros[: , j: j+1]
+            weight[:, j * self.tile_cols: (j + 1) * self.tile_cols] *= self.scales[: , j: j+1]
+        return weight
 
-        torch_linear_cls = torch.nn.Linear
-        torch.nn.Linear = Linear8bitLt
-        yield
-        torch.nn.Linear = torch_linear_cls
+    def forward(self, inp):
+        weight = self.get_weight(dtype=inp.dtype)
+        return torch.nn.functional.linear(inp, weight, self.bias)
+
+
+
+
+class GPTQQuantizer:
+    # The algorithm and code has been taken from  https://github.com/IST-DASLab/gptq/
+    # E. Frantar et al GPTQ: Accurate Post-training Compression for GPT, arXiv:2210.17323
+    # portions copyright by the authors licensed under the Apache License 2.0
+    # All errors are our own.
+
+    def __init__(self, linear_module, *, bits, perchannel=True, sym=False, blocksize=128, percdamp=.01, groupsize=-1, actorder=False):
+        assert isinstance(linear_module, torch.nn.Linear)
+
+        self.linear_module = linear_module
+        self.dev = self.linear_module.weight.device
+        self.rows = linear_module.weight.shape[0]
+        self.columns = linear_module.weight.shape[1]
+        self.H = torch.zeros((self.columns, self.columns), device=self.dev)
+        self.nsamples = 0
+        self.bits = bits
+        self.maxq = 2 ** bits - 1
+        self.perchannel = perchannel
+        self.sym = sym
+        self.blocksize = blocksize
+        self.percdamp = percdamp
+        self.groupsize = groupsize
+        self.actorder = actorder
+        self.tile_cols = self.columns if groupsize == -1 else groupsize
+        self.scales = torch.zeros((self.rows, (self.columns + self.tile_cols - 1) // self.tile_cols), dtype=self.linear_module.weight.dtype, device = self.dev)
+        self.zeros = torch.zeros_like(self.scales)
+        assert not (self.actorder and self.groupsize != -1), "The permutation trick does not work for grouped quantization"
+
+    @staticmethod
+    def quantize_weight(x, scale, zero, maxq):
+        q = torch.clamp(torch.round(x / scale) + zero, 0, maxq)
+        x_rec = scale * (q - zero)
+        return x_rec
+
+    def find_params_weight(self, x):
+        dev = x.device
+
+        shape = x.shape
+        if self.perchannel:
+            x = x.flatten(1)
+        else:
+            x = x.flatten().unsqueeze(0)
+
+        tmp = torch.zeros(x.shape[0], device=dev)
+        xmin = torch.minimum(x.min(1)[0], tmp)
+        xmax = torch.maximum(x.max(1)[0], tmp)
+
+        if self.sym:
+            xmax = torch.maximum(torch.abs(xmin), xmax)
+            tmp = xmin < 0
+            if torch.any(tmp):
+                xmin[tmp] = -xmax[tmp]
+        tmp = (xmin == 0) & (xmax == 0)
+        xmin[tmp] = -1
+        xmax[tmp] = +1
+
+        scale = (xmax - xmin) / self.maxq
+        if self.sym:
+            zero = torch.full_like(scale, (self.maxq + 1) / 2)
+        else:
+            zero = torch.round(-xmin / scale)
+
+        if not self.perchannel:
+            tmp = shape[0]
+            scale = scale.repeat(tmp)
+            zero = zero.repeat(tmp)
+
+        shape = [-1] + [1] * (len(shape) - 1)
+        scale = scale.reshape(shape)
+        zero = zero.reshape(shape)
+        return scale, zero
+
+    def collect_input_stats(self, _1, inp, _2):
+        inp = inp[0].detach()
+        self.last_inp = inp
+        if len(inp.shape) == 2:
+            inp = inp.unsqueeze(0)
+        tmp = inp.shape[0]
+        if len(inp.shape) == 3:
+            inp = inp.reshape((-1, inp.shape[-1]))
+        inp = inp.t()
+        self.H *= self.nsamples / (self.nsamples + tmp)
+        self.nsamples += tmp
+        # inp = inp.float()
+        inp = math.sqrt(2 / self.nsamples) * inp.float()
+        # self.H += 2 / self.nsamples * inp.matmul(inp.t())
+        self.H += inp.matmul(inp.t())
+
+    def quantize(self):
+        W = self.linear_module.weight.detach().to(dtype=torch.float, copy=True)
+
+        scale, zero = self.find_params_weight(W)
+        self.scales[:] = scale
+        self.zeros[:] = zero
+
+        H = self.H
+        del self.H
+        dead = torch.diag(H) == 0
+        H[dead, dead] = 1
+        W[:, dead] = 0
+        if self.actorder:
+            perm = torch.argsort(torch.diag(H), descending=True)
+            W = W[:, perm]
+            H = H[perm][:, perm]
+
+        Losses = torch.zeros_like(W)
+        Q = torch.zeros_like(W)
+
+        damp = self.percdamp * torch.mean(torch.diag(H))
+        diag = torch.arange(self.columns, device=self.dev)
+        H[diag, diag] += damp
+        H = torch.linalg.cholesky(H)
+        H = torch.cholesky_inverse(H)
+        H = torch.linalg.cholesky(H, upper=True)
+        Hinv = H
+
+        for i1 in range(0, self.columns, self.blocksize):
+            i2 = min(i1 + self.blocksize, self.columns)
+            count = i2 - i1
+
+            W1 = W[:, i1:i2].clone()
+            Q1 = torch.zeros_like(W1)
+            Err1 = torch.zeros_like(W1)
+            Losses1 = torch.zeros_like(W1)
+            Hinv1 = Hinv[i1:i2, i1:i2]
+
+            for i in range(count):
+                w = W1[:, i]
+                d = Hinv1[i, i]
+
+                if self.groupsize != -1:
+                    if (i1 + i) % self.groupsize == 0:
+                        scale, zero = self.find_params_weight(W[:, (i1 + i):(i1 + i + self.groupsize)])
+                        self.scales[:, (i1 + i) // self.groupsize] = scale
+                        self.zeros[:, (i1 + i) // self.groupsize] = zeros
+
+                q = self.quantize_weight(
+                    w.unsqueeze(1), scale, zero, self.maxq
+                )
+                q = q.squeeze(1)
+                assert q.dim() == 1
+                Q1[:, i] = q
+                Losses1[:, i] = (w - q) ** 2 / d ** 2
+
+                err1 = (w - q) / d
+                W1[:, i:] -= err1.unsqueeze(1).matmul(Hinv1[i, i:].unsqueeze(0))
+                Err1[:, i] = err1
+
+            Q[:, i1:i2] = Q1
+            Losses[:, i1:i2] = Losses1 / 2
+
+            W[:, i2:] -= Err1.matmul(Hinv[i1:i2, i2:])
+
+        if self.actorder:
+            invperm = torch.argsort(perm)
+            Q = Q[:, invperm]
+
+        weight = Q.reshape(self.linear_module.weight.shape).to(self.linear_module.weight.data.dtype)
+        error = torch.sum(Losses).item()
+
+        q_module = ColBlockQuantizedLinear(self.linear_module.in_features, self.linear_module.out_features, self.linear_module.bias is not None,
+                                           bits=self.bits, tile_cols=self.groupsize).to(self.dev)
+        q_module.scales = self.scales
+        q_module.zeros = self.zeros
+        q_module.pack_weight(weight)
+        q_module.bias = self.linear_module.bias
+        return q_module, error

--- a/lit_llama/utils.py
+++ b/lit_llama/utils.py
@@ -1,6 +1,7 @@
 """Utility functions for training and inference."""
 
 import torch
+import functools
 from lightning.fabric.strategies import FSDPStrategy
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.distributed.fsdp import StateDictType, FullStateDictConfig
@@ -42,22 +43,28 @@ class EmptyInitOnDevice(torch.overrides.TorchFunctionMode):
             model.load_state_dict(torch.load('llama-lit/7B/state_dict.pth'))"""
 
         self.quantization_mode = quantization_mode
+        self.quantized_linear_cls = None
         if self.quantization_mode == 'llm.int8':
             if device.type != "cuda":
                 raise ValueError("Quantization is only supported on the GPU.")
             from .quantization import Linear8bitLt
-            self.Linear8bitLt = Linear8bitLt
+            self.quantized_linear_cls = Linear8bitLt
+        elif self.quantization_mode == 'gptq.int4':
+            from .quantization import ColBlockQuantizedLinear
+            self.quantized_linear_cls = functools.partial(ColBlockQuantizedLinear, bits=4, tile_cols=-1)
+        elif self.quantization_mode is not None:
+            raise RuntimeError(f"unknown quantization mode {self.quantization_mode}")
         self.device = device
         self.dtype = dtype
 
     def __enter__(self):
-        if self.quantization_mode == 'llm.int8':
+        if self.quantized_linear_cls != None:
             self.torch_linear_cls = torch.nn.Linear
-            torch.nn.Linear = self.Linear8bitLt
+            torch.nn.Linear = self.quantized_linear_cls
         return super().__enter__()
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if self.quantization_mode == 'llm.int8':
+        if self.quantized_linear_cls != None:
             torch.nn.Linear = self.torch_linear_cls
         return super().__exit__(exc_type, exc_val, exc_tb)
 


### PR DESCRIPTION
This adds int4 quantization, bringing the 7B model's GPU memory usage for generation to about ~5GB
The obvious next step is triton quantized matmul kernels to recover the performance.
Quantization takes <= 15 minutes when not disabling the TF32 matmuls (GPTQ upstream does this), I am not sure about the accuracy impact yet.
