### PR TITLE
Fix weight initialization in LoRA and Adapter finetuning

### DIFF
--- a/finetune_adapter.py
+++ b/finetune_adapter.py
@@ -55,8 +55,10 @@ def main():
 
     checkpoint = torch.load("checkpoints/lit-llama/7B/state_dict.pth")
 
-    with EmptyInitOnDevice(device=fabric.device, dtype=torch.bfloat16):
-        model = LLaMA(config)
+    with fabric.device:
+        torch.set_default_tensor_type(torch.HalfTensor)
+        model = LLaMA(config).bfloat16()
+        torch.set_default_tensor_type(torch.FloatTensor)
         # strict=False because missing keys due to adapter weights not containted in state dict
         model.load_state_dict(checkpoint, strict=False)
     

--- a/lit_llama/adapter.py
+++ b/lit_llama/adapter.py
@@ -93,7 +93,7 @@ class CausalSelfAttention(nn.Module):
             ak = ak.view(1, aT, self.n_head, head_size).repeat(B, 1, 1, 1).transpose(1, 2)
             av = av.view(1, aT, self.n_head, head_size).repeat(B, 1, 1, 1).transpose(1, 2)
 
-            amask = torch.ones(q.shape[-2], ak.shape[-2], dtype=torch.bool)
+            amask = torch.ones(q.shape[-2], ak.shape[-2], dtype=torch.bool, device=x.device)
             ay = F.scaled_dot_product_attention(q, ak, av, attn_mask=amask, dropout_p=0.0, is_causal=False)
             y = y + self.gating_factor * ay
 


### PR DESCRIPTION
Fixes #116

In #100 I accidentally applied the EmptyInitOnDevice context manager over the adapter/LoRA weights. 