### PR TITLE
Batch hf conversion to save ram

### DIFF
--- a/evaluate.py
+++ b/evaluate.py
@@ -78,6 +78,8 @@ def main(
         if not isinstance(dt, torch.dtype):
             raise ValueError(f"{dtype} is not a valid dtype.")
         dtype = dt
+    else:
+        dtype = torch.float32
 
     with EmptyInitOnDevice(
         device=fabric.device, dtype=dtype, quantization_mode=quantize

--- a/evaluate.py
+++ b/evaluate.py
@@ -48,7 +48,7 @@ def main(
     checkpoint_path: Optional[Path] = None,
     tokenizer_path: Optional[Path] = None,
     model_size: str = "7B",
-    dtype: Optional[str] = None,
+    dtype: str = "float32",
     quantize: Optional[str] = None,
 ) -> None:
     """Generates text samples based on a pre-trained LLaMA model and tokenizer.
@@ -73,13 +73,10 @@ def main(
 
     fabric = L.Fabric(accelerator=accelerator, devices=1)
 
-    if dtype is not None:
-        dt = getattr(torch, dtype, None)
-        if not isinstance(dt, torch.dtype):
-            raise ValueError(f"{dtype} is not a valid dtype.")
-        dtype = dt
-    else:
-        dtype = torch.float32
+    dt = getattr(torch, dtype, None)
+    if not isinstance(dt, torch.dtype):
+        raise ValueError(f"{dtype} is not a valid dtype.")
+    dtype = dt
 
     with EmptyInitOnDevice(
         device=fabric.device, dtype=dtype, quantization_mode=quantize

--- a/generate.py
+++ b/generate.py
@@ -77,7 +77,7 @@ def main(
     checkpoint_path: Optional[Path] = None,
     tokenizer_path: Optional[Path] = None,
     model_size: str = "7B",
-    dtype: Optional[str] = None,
+    dtype: str = "float32",
     quantize: Optional[str] = None,
 ) -> None:
     """Generates text samples based on a pre-trained LLaMA model and tokenizer.
@@ -94,6 +94,7 @@ def main(
             ``"cpu"``, ``"cuda"``, ``"mps"``, ``"gpu"``, ``"tpu"``, ``"auto"``.
         checkpoint_path: The checkpoint path to load.
         tokenizer_path: The tokenizer path to load.
+        dtype: The dtype to use during generation.
         quantize: Whether to quantize the model and using which method:
             ``"llm.int8"``: LLM.int8() mode,
             ``"gptq.int4"``: GPTQ 4-bit mode.
@@ -107,13 +108,10 @@ def main(
 
     fabric = L.Fabric(accelerator=accelerator, devices=1)
 
-    if dtype is not None:
-        dt = getattr(torch, dtype, None)
-        if not isinstance(dt, torch.dtype):
-            raise ValueError(f"{dtype} is not a valid dtype.")
-        dtype = dt
-    else:
-        dtype = torch.float32
+    dt = getattr(torch, dtype, None)
+    if not isinstance(dt, torch.dtype):
+        raise ValueError(f"{dtype} is not a valid dtype.")
+    dtype = dt
 
     with EmptyInitOnDevice(
         device=fabric.device, dtype=dtype, quantization_mode=quantize

--- a/generate.py
+++ b/generate.py
@@ -111,6 +111,8 @@ def main(
         if not isinstance(dt, torch.dtype):
             raise ValueError(f"{dtype} is not a valid dtype.")
         dtype = dt
+    else:
+        dtype = torch.float32
 
     with EmptyInitOnDevice(
         device=fabric.device, dtype=dtype, quantization_mode=quantize

--- a/generate_adapter.py
+++ b/generate_adapter.py
@@ -21,7 +21,7 @@ def main(
     pretrained_path: Optional[Path] = None,
     tokenizer_path: Optional[Path] = None,
     quantize: Optional[str] = None,
-    dtype: Optional[str] = None,
+    dtype: str = "float32",
     max_new_tokens: int = 100,
     top_k: int = 200,
     temperature: float = 0.8,
@@ -41,6 +41,7 @@ def main(
         quantize: Whether to quantize the model and using which method:
             ``"llm.int8"``: LLM.int8() mode,
             ``"gptq.int4"``: GPTQ 4-bit mode.
+        dtype: The dtype to use during generation.
         max_new_tokens: The number of generation steps to take.
         top_k: The number of top most probable tokens to consider in the sampling process.
         temperature: A value controlling the randomness of the sampling process. Higher values result in more random
@@ -61,11 +62,10 @@ def main(
 
     fabric = L.Fabric(accelerator=accelerator, devices=1)
 
-    if dtype is not None:
-        dt = getattr(torch, dtype, None)
-        if not isinstance(dt, torch.dtype):
-            raise ValueError(f"{dtype} is not a valid dtype.")
-        dtype = dt
+    dt = getattr(torch, dtype, None)
+    if not isinstance(dt, torch.dtype):
+        raise ValueError(f"{dtype} is not a valid dtype.")
+    dtype = dt
 
     with EmptyInitOnDevice(
         device=fabric.device, dtype=dtype, quantization_mode=quantize

--- a/quantize.py
+++ b/quantize.py
@@ -146,7 +146,7 @@ def main(
     tokenizer_path: Optional[Path] = None,
     n_samples: int = 128,
     model_size: str = "7B",
-    dtype: Optional[str] = None,
+    dtype: str = "float32",
     quantize: Optional[str] = None,
 ) -> None:
     """Generates text samples based on a pre-trained LLaMA model and tokenizer.
@@ -158,6 +158,7 @@ def main(
         output_path: Path to write the quantized model's state dict to.
         tokenizer_path: The tokenizer path to load.
         n_samples: Number of example inputs to use for statistics (default: 128)
+        dtype: The dtype to use to load the model.
         quantize: Mode to quantize the model to:
             ``"gptq.int4"``: GPTQ 4-bit mode.
             Note that ``"llm.int8"```does not need a quantization step.
@@ -174,11 +175,10 @@ def main(
 
     device = "cuda"
 
-    if dtype is not None:
-        dt = getattr(torch, dtype, None)
-        if not isinstance(dt, torch.dtype):
-            raise ValueError(f"{dtype} is not a valid dtype.")
-        dtype = dt
+    dt = getattr(torch, dtype, None)
+    if not isinstance(dt, torch.dtype):
+        raise ValueError(f"{dtype} is not a valid dtype.")
+    dtype = dt
 
     if quantize == "gptq.int4":
         bits = 4

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ numpy  # train.py dataset memmap
 jsonargparse[signatures]  # generate.py, convert_checkpoint.py CLI
 bitsandbytes  # quantization.py
 datasets  # evaluate.py
+git+https://github.com/huggingface/transformers

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ numpy  # train.py dataset memmap
 jsonargparse[signatures]  # generate.py, convert_checkpoint.py CLI
 bitsandbytes  # quantization.py
 datasets  # evaluate.py
-git+https://github.com/huggingface/transformers

--- a/scripts/convert_checkpoint.py
+++ b/scripts/convert_checkpoint.py
@@ -83,6 +83,8 @@ def meta_weights_for_nano_model(
         if not isinstance(dt, torch.dtype):
             raise ValueError(f"{dtype} is not a valid dtype.")
         dtype = dt
+    else:
+        dtype = torch.float32
 
     # the tokenizer is the same for all model sizes, so we store it in the parent dir
     if "tokenizer.model" not in os.listdir(output_dir.parent):

--- a/scripts/convert_checkpoint.py
+++ b/scripts/convert_checkpoint.py
@@ -72,19 +72,16 @@ def meta_weights_for_nano_model(
     ckpt_dir: Path = Path("checkpoints/llama/"),
     tokenizer_path: Path = Path("checkpoints/llama/tokenizer.model"),
     model_size: str = "7B",
-    dtype: str = None,
+    dtype: str = "float32",
 ) -> None:
     output_dir = output_dir / model_size
     ckpt_dir = ckpt_dir / model_size
     os.makedirs(output_dir, exist_ok=True)
 
-    if dtype is not None:
-        dt = getattr(torch, dtype, None)
-        if not isinstance(dt, torch.dtype):
-            raise ValueError(f"{dtype} is not a valid dtype.")
-        dtype = dt
-    else:
-        dtype = torch.float32
+    dt = getattr(torch, dtype, None)
+    if not isinstance(dt, torch.dtype):
+        raise ValueError(f"{dtype} is not a valid dtype.")
+    dtype = dt
 
     # the tokenizer is the same for all model sizes, so we store it in the parent dir
     if "tokenizer.model" not in os.listdir(output_dir.parent):

--- a/scripts/convert_hf_checkpoint.py
+++ b/scripts/convert_hf_checkpoint.py
@@ -1,14 +1,18 @@
 from pathlib import Path
-
+import sys
 # support running without installing as a package
 wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
-from transformers import LlamaForCausalLM
 import torch
-
 from lit_llama.model import LLaMA, LLaMAConfig
+import os
+import json
+from transformers import LlamaForCausalLM
 
+def load_weights_from_bin(weight_path: Path, weight_file: str) -> torch.Tensor:
+    weights = torch.load(weight_path / weight_file, map_location="cpu")
+    return weights
 
 def convert_hf_checkpoint(
     model_size: str = "7B",
@@ -16,6 +20,8 @@ def convert_hf_checkpoint(
     lit_checkpoint: Path = Path("checkpoints/lit-llama.ckpt"),
     verify: bool = False,
 ) -> None:
+
+
     """
     Perform the reverse operation of: https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama/convert_llama_weights_to_hf.py
     """
@@ -23,14 +29,25 @@ def convert_hf_checkpoint(
     print("Loading weights from pretrained LLaMA %s" % model_size)
 
     config = LLaMAConfig.from_name(model_size)
-    model = LLaMA(config)
-    sd = model.state_dict()
 
-    model_hf = LlamaForCausalLM.from_pretrained(hf_checkpoint_path)
-    sd_hf = model_hf.state_dict()
+    print("Loaded config %s, please wait for model loading" % config)
+
+    model = LLaMA(config)
+    print("Initialized lit-style instance of llama")
+    sd = model.state_dict()
 
     qkv_size = model.transformer.h[0].attn.c_attn.weight.shape[0] // 3
     n_blocks = len(model.transformer.h)
+
+    print("Finished loading model")
+
+    # initialize a new empty state dict to hold our new weights
+    sd = model.state_dict()
+
+    # Load the json file containing weight mapping
+    pytorch_bin_map_json_path = os.path.join(hf_checkpoint_path, "pytorch_model.bin.index.json")
+    with open(pytorch_bin_map_json_path) as json_map:
+        bin_index = json.load(json_map)
 
     def permute(w):
         dim = config.n_embd
@@ -41,43 +58,70 @@ def convert_hf_checkpoint(
         )
 
     with torch.no_grad():
-        sd["transformer.wte.weight"].copy_(sd_hf["model.embed_tokens.weight"])
-        sd["transformer.ln_f.scale"].copy_(sd_hf["model.norm.weight"])
-        sd["lm_head.weight"].copy_(sd_hf["lm_head.weight"])
+
+        print("Total blocks to process: %s" % n_blocks)
 
         for i in range(n_blocks):
-            sd[f"transformer.h.{i}.attn.c_proj.weight"].copy_(
-                sd_hf[f"model.layers.{i}.self_attn.o_proj.weight"]
-            )
+            print("Processing block %s" % i)
 
-            sd[f"transformer.h.{i}.attn.c_attn.weight"][:qkv_size] = permute(
-                sd_hf[f"model.layers.{i}.self_attn.q_proj.weight"]
-            )
-            sd[f"transformer.h.{i}.attn.c_attn.weight"][qkv_size:-qkv_size] = permute(
-                sd_hf[f"model.layers.{i}.self_attn.k_proj.weight"]
-            )
-            sd[f"transformer.h.{i}.attn.c_attn.weight"][-qkv_size:] = sd_hf[
-                f"model.layers.{i}.self_attn.v_proj.weight"
-            ]
+            for layer_name, bin_file in bin_index["weight_map"].items():
+                if f"model.layers.{i}." in layer_name:
+                    # Load the weight tensor from the .bin file,
 
-            sd[f"transformer.h.{i}.mlp.c_fc1.weight"].copy_(
-                sd_hf[f"model.layers.{i}.mlp.gate_proj.weight"]
-            )
-            sd[f"transformer.h.{i}.mlp.c_fc2.weight"].copy_(
-                sd_hf[f"model.layers.{i}.mlp.up_proj.weight"]
-            )
-            sd[f"transformer.h.{i}.mlp.c_proj.weight"].copy_(
-                sd_hf[f"model.layers.{i}.mlp.down_proj.weight"]
-            )
+                    hf_weights = load_weights_from_bin(hf_checkpoint_path, bin_file)
+                    print(f"Loading layer {i} weights from bin file {bin_file}")
+                    sd[f"transformer.h.{i}.attn.c_proj.weight"].copy_(
+                        hf_weights[f"model.layers.{i}.self_attn.o_proj.weight"]
+                    )
 
-            sd[f"transformer.h.{i}.rms_1.scale"].copy_(
-                sd_hf[f"model.layers.{i}.input_layernorm.weight"]
-            )
-            sd[f"transformer.h.{i}.rms_2.scale"].copy_(
-                sd_hf[f"model.layers.{i}.post_attention_layernorm.weight"]
-            )
+                    sd[f"transformer.h.{i}.attn.c_attn.weight"][:qkv_size] = permute(
+                        hf_weights[f"model.layers.{i}.self_attn.q_proj.weight"]
+                    )
+                    sd[f"transformer.h.{i}.attn.c_attn.weight"][qkv_size:-qkv_size] = permute(
+                        hf_weights[f"model.layers.{i}.self_attn.k_proj.weight"]
+                    )
+                    sd[f"transformer.h.{i}.attn.c_attn.weight"][-qkv_size:] = hf_weights[
+                        f"model.layers.{i}.self_attn.v_proj.weight"
+                    ]
+
+                    sd[f"transformer.h.{i}.mlp.c_fc1.weight"].copy_(
+                        hf_weights[f"model.layers.{i}.mlp.gate_proj.weight"]
+                    )
+                    sd[f"transformer.h.{i}.mlp.c_fc2.weight"].copy_(
+                        hf_weights[f"model.layers.{i}.mlp.up_proj.weight"]
+                    )
+                    sd[f"transformer.h.{i}.mlp.c_proj.weight"].copy_(
+                        hf_weights[f"model.layers.{i}.mlp.down_proj.weight"]
+                    )
+
+                    sd[f"transformer.h.{i}.rms_1.scale"].copy_(
+                        hf_weights[f"model.layers.{i}.input_layernorm.weight"]
+                    )
+                    sd[f"transformer.h.{i}.rms_2.scale"].copy_(
+                        hf_weights[f"model.layers.{i}.post_attention_layernorm.weight"]
+                    )
+
+                    # Load globals, could be done in a cleaner way. It assumes that the globals will happen to be in a .bin
+                    # ... file that also contains some layers, hopefully always the case
+                    if "model.embed_tokens.weight" in hf_weights:
+                        sd["transformer.wte.weight"].copy_(hf_weights["model.embed_tokens.weight"])
+
+                    if "model.norm.weight" in hf_weights:
+                        sd["transformer.ln_f.scale"].copy_(hf_weights["model.norm.weight"])
+
+                    if "lm_head.weight" in hf_weights:
+                        sd["lm_head.weight"].copy_(hf_weights["lm_head.weight"])
+
+                    # Break here to avoid reloading the same weights multiple times
+                    # this assumes the layers won't be split between bin files, which hopefully is not possible
+                    break
+
 
     if verify:
+        print("Verifying...")
+        print("Loading huggingface model for comparison. This will use a lot of ram and take a while. You'll certainly run out with less than 64gb of cpu ram")
+        model_hf = LlamaForCausalLM.from_pretrained(hf_checkpoint_path)
+
         token_sample = torch.randint(
             0, config.vocab_size, size=(1, config.block_size), dtype=torch.int64
         )
@@ -85,9 +129,10 @@ def convert_hf_checkpoint(
         with torch.no_grad():
             out = model(token_sample)
             out_hf = model_hf(token_sample)
-
+        print("Comparing tokenization outputs")
         assert torch.allclose(out, out_hf["logits"])
 
+    print("Saving to disk at %s " % lit_checkpoint)
     torch.save(model.state_dict(), lit_checkpoint)
 
 

--- a/scripts/convert_hf_checkpoint.py
+++ b/scripts/convert_hf_checkpoint.py
@@ -1,3 +1,7 @@
+
+import gc
+import os
+import json
 from pathlib import Path
 import sys
 # support running without installing as a package
@@ -6,40 +10,35 @@ sys.path.append(str(wd))
 
 import torch
 from lit_llama.model import LLaMA, LLaMAConfig
-import os
-import json
-from transformers import LlamaForCausalLM
 
-def load_weights_from_bin(weight_path: Path, weight_file: str) -> torch.Tensor:
-    weights = torch.load(weight_path / weight_file, map_location="cpu")
-    return weights
 
 def convert_hf_checkpoint(
     model_size: str = "7B",
     hf_checkpoint_path: Path = Path("checkpoints/llama-7b-hf"),
     lit_checkpoint: Path = Path("checkpoints/lit-llama.ckpt"),
+    dtype: str = None,
     verify: bool = False,
 ) -> None:
-
-
     """
     Perform the reverse operation of: https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama/convert_llama_weights_to_hf.py
     """
 
-    print("Loading weights from pretrained LLaMA %s" % model_size)
+    if dtype is not None:
+        dt = getattr(torch, dtype, None)
+        if not isinstance(dt, torch.dtype):
+            raise ValueError(f"{dtype} is not a valid dtype.")
+        dtype = dt
+    else:
+        dtype = torch.float32
 
+    print("Initializing lit-llama")
     config = LLaMAConfig.from_name(model_size)
 
-    print("Loaded config %s, please wait for model loading" % config)
+    with EmptyInitOnDevice(device="cpu", dtype=dtype):
+        model = LLaMA(config)
 
-    model = LLaMA(config)
-    print("Initialized lit-style instance of llama")
     sd = model.state_dict()
-
     qkv_size = model.transformer.h[0].attn.c_attn.weight.shape[0] // 3
-    n_blocks = len(model.transformer.h)
-
-    print("Finished loading model")
 
     # initialize a new empty state dict to hold our new weights
     sd = model.state_dict()
@@ -57,70 +56,55 @@ def convert_hf_checkpoint(
             .reshape(dim, dim)
         )
 
-    with torch.no_grad():
+    bin_files = set(el for el in bin_index["weight_map"].values())
 
-        print("Total blocks to process: %s" % n_blocks)
+    weight_map = {
+        "self_attn.o_proj.weight": "attn.c_proj.weight",
+        "self_attn.q_proj.weight": "attn.c_attn.weight",
+        "self_attn.k_proj.weight": "attn.c_attn.weight",
+        "self_attn.v_proj.weight": "attn.c_attn.weight",
+        "mlp.gate_proj.weight": "mlp.c_fc1.weight",
+        "mlp.up_proj.weight": "mlp.c_fc2.weight",
+        "mlp.down_proj.weight": "mlp.c_proj.weight",
+        "input_layernorm.weight": "rms_1.scale",
+        "post_attention_layernorm.weight": "rms_2.scale",
+        "model.embed_tokens.weight": "transformer.wte.weight",
+        "model.norm.weight": "transformer.ln_f.scale",
+        "lm_head.weight": "lm_head.weight"
+    }
 
-        for i in range(n_blocks):
-            print("Processing block %s" % i)
+    for bin_file in bin_files:
+        print("Processing", hf_checkpoint_path)
 
-            for layer_name, bin_file in bin_index["weight_map"].items():
-                if f"model.layers.{i}." in layer_name:
-                    # Load the weight tensor from the .bin file,
+        hf_weights = torch.load(os.path.join(hf_checkpoint_path, bin_file), map_location="cpu")
 
-                    hf_weights = load_weights_from_bin(hf_checkpoint_path, bin_file)
-                    print(f"Loading layer {i} weights from bin file {bin_file}")
-                    sd[f"transformer.h.{i}.attn.c_proj.weight"].copy_(
-                        hf_weights[f"model.layers.{i}.self_attn.o_proj.weight"]
-                    )
+        with torch.no_grad():
+            for name, param in hf_weights.items():
+                param = param.to(dtype=dtype)
+                if "model.layers" in name:
+                    block_id = int(name.split(".")[2])
+                    from_name = ".".join(name.split(".")[3:])
+                    to_name = weight_map[from_name]
 
-                    sd[f"transformer.h.{i}.attn.c_attn.weight"][:qkv_size] = permute(
-                        hf_weights[f"model.layers.{i}.self_attn.q_proj.weight"]
-                    )
-                    sd[f"transformer.h.{i}.attn.c_attn.weight"][qkv_size:-qkv_size] = permute(
-                        hf_weights[f"model.layers.{i}.self_attn.k_proj.weight"]
-                    )
-                    sd[f"transformer.h.{i}.attn.c_attn.weight"][-qkv_size:] = hf_weights[
-                        f"model.layers.{i}.self_attn.v_proj.weight"
-                    ]
+                    if "q_proj" in name:
+                        sd[f"transformer.h.{block_id}.{to_name}"][:qkv_size] = permute(param)
+                    elif "k_proj" in name:
+                        sd[f"transformer.h.{block_id}.{to_name}"][qkv_size:-qkv_size] = permute(param)
+                    elif "v_proj" in name:
+                        sd[f"transformer.h.{block_id}.{to_name}"][-qkv_size:] = param
+                    else:
+                        sd[f"transformer.h.{block_id}.{to_name}"].copy_(param)
+                else:
+                    sd[weight_map[name]].copy_(param)
 
-                    sd[f"transformer.h.{i}.mlp.c_fc1.weight"].copy_(
-                        hf_weights[f"model.layers.{i}.mlp.gate_proj.weight"]
-                    )
-                    sd[f"transformer.h.{i}.mlp.c_fc2.weight"].copy_(
-                        hf_weights[f"model.layers.{i}.mlp.up_proj.weight"]
-                    )
-                    sd[f"transformer.h.{i}.mlp.c_proj.weight"].copy_(
-                        hf_weights[f"model.layers.{i}.mlp.down_proj.weight"]
-                    )
+        del hf_weights
+        gc.collect()
 
-                    sd[f"transformer.h.{i}.rms_1.scale"].copy_(
-                        hf_weights[f"model.layers.{i}.input_layernorm.weight"]
-                    )
-                    sd[f"transformer.h.{i}.rms_2.scale"].copy_(
-                        hf_weights[f"model.layers.{i}.post_attention_layernorm.weight"]
-                    )
-
-                    # Load globals, could be done in a cleaner way. It assumes that the globals will happen to be in a .bin
-                    # ... file that also contains some layers, hopefully always the case
-                    if "model.embed_tokens.weight" in hf_weights:
-                        sd["transformer.wte.weight"].copy_(hf_weights["model.embed_tokens.weight"])
-
-                    if "model.norm.weight" in hf_weights:
-                        sd["transformer.ln_f.scale"].copy_(hf_weights["model.norm.weight"])
-
-                    if "lm_head.weight" in hf_weights:
-                        sd["lm_head.weight"].copy_(hf_weights["lm_head.weight"])
-
-                    # Break here to avoid reloading the same weights multiple times
-                    # this assumes the layers won't be split between bin files, which hopefully is not possible
-                    break
-
+    print(f"Saving to disk at {lit_checkpoint}")
+    torch.save(model.state_dict(), lit_checkpoint)
 
     if verify:
         print("Verifying...")
-        print("Loading huggingface model for comparison. This will use a lot of ram and take a while. You'll certainly run out with less than 64gb of cpu ram")
-        model_hf = LlamaForCausalLM.from_pretrained(hf_checkpoint_path)
 
         token_sample = torch.randint(
             0, config.vocab_size, size=(1, config.block_size), dtype=torch.int64
@@ -128,15 +112,27 @@ def convert_hf_checkpoint(
 
         with torch.no_grad():
             out = model(token_sample)
-            out_hf = model_hf(token_sample)
-        print("Comparing tokenization outputs")
-        assert torch.allclose(out, out_hf["logits"])
 
-    print("Saving to disk at %s " % lit_checkpoint)
-    torch.save(model.state_dict(), lit_checkpoint)
+        del model
+        gc.collect()
+
+        print("Loading original model for comparison.")
+
+        try:
+            from transformers import LlamaForCausalLM
+        except ImportError as e:
+            print("verify=True requires transformers to be installed, please `pip install transformers`")
+
+        model_hf = LlamaForCausalLM.from_pretrained(hf_checkpoint_path)
+
+        out_hf = model_hf(token_sample)
+
+        print("Comparing outputs")
+        assert torch.allclose(out, out_hf["logits"])
 
 
 if __name__ == "__main__":
     from jsonargparse import CLI
 
     CLI(convert_hf_checkpoint)
+

--- a/scripts/convert_hf_checkpoint.py
+++ b/scripts/convert_hf_checkpoint.py
@@ -47,6 +47,8 @@ def convert_hf_checkpoint(
     with open(pytorch_bin_map_json_path) as json_map:
         bin_index = json.load(json_map)
 
+    bin_files = set(el for el in bin_index["weight_map"].values())
+
     def permute(w):
         dim = config.n_embd
         return (
@@ -54,8 +56,6 @@ def convert_hf_checkpoint(
             .transpose(1, 2)
             .reshape(dim, dim)
         )
-
-    bin_files = set(el for el in bin_index["weight_map"].values())
 
     weight_map = {
         "self_attn.o_proj.weight": "attn.c_proj.weight",

--- a/scripts/convert_hf_checkpoint.py
+++ b/scripts/convert_hf_checkpoint.py
@@ -18,20 +18,17 @@ def convert_hf_checkpoint(
     model_size: str = "7B",
     hf_checkpoint_path: Path = Path("checkpoints/llama-7b-hf"),
     lit_checkpoint: Path = Path("checkpoints/lit-llama.ckpt"),
-    dtype: Optional[str] = None,
+    dtype: str = "float32",
     verify: bool = False,
 ) -> None:
     """
     Perform the reverse operation of: https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama/convert_llama_weights_to_hf.py
     """
 
-    if dtype is not None:
-        dt = getattr(torch, dtype, None)
-        if not isinstance(dt, torch.dtype):
-            raise ValueError(f"{dtype} is not a valid dtype.")
-        dtype = dt
-    else:
-        dtype = torch.float32
+    dt = getattr(torch, dtype, None)
+    if not isinstance(dt, torch.dtype):
+        raise ValueError(f"{dtype} is not a valid dtype.")
+    dtype = dt
 
     print("Initializing lit-llama")
     config = LLaMAConfig.from_name(model_size)


### PR DESCRIPTION
Continuation of #108 by @factoidforrest

It also supports converting to a given `dtype`, e.g. for `bfloat16` (if you omit it will convert to `float32`):

```
python scripts/convert_hf_checkpoint.py --hf_checkpoint_path checkpoints/llama-hf/llama-13b-hf --lit_checkpoint lit-llama.pth --model_size 13B --dtype bfloat16
```

It's much faster than before and it uses way less memory.