### PR TITLE
Enable checkpoint with FSDP on single device

### DIFF
--- a/lit_llama/utils.py
+++ b/lit_llama/utils.py
@@ -15,7 +15,7 @@ def save_model_checkpoint(fabric, model, file_path):
     """
 
     if isinstance(fabric.strategy, FSDPStrategy):
-        save_policy = FullStateDictConfig(offload_to_cpu=True, rank0_only=True)
+        save_policy = FullStateDictConfig(offload_to_cpu=(fabric.world_size > 1), rank0_only=True)
         with FSDP.state_dict_type(model, StateDictType.FULL_STATE_DICT, save_policy):
             state_dict = model._forward_module.state_dict()
     else:


### PR DESCRIPTION
Fixes  #113

In #113, the user wants to run the training with FSDP but with a single device. FSDP does not support offloading the checkpoint state to CPU if world-size is 1. 