### PR TITLE
DeepSpeed checkpoint consolidation

### DIFF
--- a/finetune_adapter.py
+++ b/finetune_adapter.py
@@ -21,6 +21,7 @@ import torch
 from generate import generate
 from lit_llama.adapter import LLaMA, LLaMAConfig, mark_only_adapter_as_trainable
 from lit_llama.tokenizer import Tokenizer
+from lit_llama.utils import save_model_checkpoint
 from scripts.prepare_alpaca import generate_prompt
 from lightning.fabric.strategies import DeepSpeedStrategy
 
@@ -94,8 +95,7 @@ def main():
     train(fabric, model, optimizer, train_data, val_data)
 
     # Save the final checkpoint at the end of training
-    checkpoint = {"model": model}
-    fabric.save(os.path.join(out_dir, f"alpaca-adapter-finetuned.pt"), checkpoint)
+    save_model_checkpoint(fabric, model, os.path.join(out_dir, "alpaca-adapter-finetuned"))
 
 
 def train(
@@ -140,9 +140,7 @@ def train(
             if step_count % save_interval == 0:
                 print(f"Saving adapter weights to {out_dir}")
                 # TODO: Provide a function/script to merge the adapter weights with pretrained weights
-                checkpoint = {"model": model}
-                fabric.save(os.path.join(out_dir, f"iter-{iter_num:06d}-ckpt.pt"), checkpoint)
-                fabric.barrier()
+                save_model_checkpoint(fabric, model, os.path.join(out_dir, f"iter-{iter_num:06d}-ckpt"))
 
         dt = time.time() - t0
         if iter_num % log_interval == 0:

--- a/finetune_adapter.py
+++ b/finetune_adapter.py
@@ -57,7 +57,7 @@ def main():
     fabric = L.Fabric(
         accelerator="cuda", 
         devices=devices, 
-        strategy=(DeepSpeedStrategy(config=ds_config) if devices > 1 else None), 
+        strategy=(DeepSpeedStrategy(config=ds_config) if devices > 1 else "auto"), 
         precision="bf16-mixed",
     )
     fabric.launch()
@@ -95,7 +95,7 @@ def main():
     train(fabric, model, optimizer, train_data, val_data)
 
     # Save the final checkpoint at the end of training
-    save_model_checkpoint(fabric, model, os.path.join(out_dir, "alpaca-adapter-finetuned"))
+    save_model_checkpoint(fabric, model, os.path.join(out_dir, "alpaca-adapter-finetuned.ckpt"))
 
 
 def train(
@@ -140,7 +140,7 @@ def train(
             if step_count % save_interval == 0:
                 print(f"Saving adapter weights to {out_dir}")
                 # TODO: Provide a function/script to merge the adapter weights with pretrained weights
-                save_model_checkpoint(fabric, model, os.path.join(out_dir, f"iter-{iter_num:06d}-ckpt"))
+                save_model_checkpoint(fabric, model, os.path.join(out_dir, f"iter-{iter_num:06d}.ckpt"))
 
         dt = time.time() - t0
         if iter_num % log_interval == 0:

--- a/lit_llama/utils.py
+++ b/lit_llama/utils.py
@@ -1,11 +1,14 @@
 """Utility functions for training and inference."""
 
-import torch
 import functools
-from lightning.fabric.strategies import FSDPStrategy
-from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
-from torch.distributed.fsdp import StateDictType, FullStateDictConfig
+from pathlib import Path
+
+import torch
 import torch.utils._device
+from lightning.fabric.strategies import DeepSpeedStrategy, FSDPStrategy
+from torch.distributed.fsdp import FullStateDictConfig
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+from torch.distributed.fsdp import StateDictType
 
 
 def save_model_checkpoint(fabric, model, file_path):
@@ -13,6 +16,18 @@ def save_model_checkpoint(fabric, model, file_path):
     
     This will be upstreamed to Fabric soon.
     """
+    file_path = Path(file_path)
+
+    if isinstance(fabric.strategy, DeepSpeedStrategy):
+        from deepspeed.utils.zero_to_fp32 import \
+            convert_zero_checkpoint_to_fp32_state_dict
+
+        fabric.save(file_path, {"model": model})
+        fabric.barrier()
+        if fabric.global_rank == 0:
+            # Create a consolidated checkpoint with the same name next to the deepspeed checkpoint
+            convert_zero_checkpoint_to_fp32_state_dict(file_path, file_path.with_suffix(".pt"))
+        return
 
     if isinstance(fabric.strategy, FSDPStrategy):
         save_policy = FullStateDictConfig(offload_to_cpu=(fabric.world_size > 1), rank0_only=True)

--- a/lit_llama/utils.py
+++ b/lit_llama/utils.py
@@ -19,8 +19,7 @@ def save_model_checkpoint(fabric, model, file_path):
     file_path = Path(file_path)
 
     if isinstance(fabric.strategy, DeepSpeedStrategy):
-        from deepspeed.utils.zero_to_fp32 import \
-            convert_zero_checkpoint_to_fp32_state_dict
+        from deepspeed.utils.zero_to_fp32 import convert_zero_checkpoint_to_fp32_state_dict
 
         fabric.save(file_path, {"model": model})
         fabric.barrier()


### PR DESCRIPTION
Consolidates the deepspeed checkpoint to a single file for easier loading at inference (at inference we don't require deepspeed to be set up). 

User no longer needs to convert the checkpoint manually. The generate_adapter.py script will work without extra steps needed after running finetune_adapter.py