### PR TITLE
Save and load only adapter weights

### DIFF
--- a/finetune_adapter.py
+++ b/finetune_adapter.py
@@ -13,15 +13,15 @@ Note: If you run into a CUDA error "Expected is_sm80 to be true, but got false",
 """
 import os
 import time
+from pathlib import Path
 
 import lightning as L
 import numpy as np
 import torch
 
 from generate import generate
-from lit_llama.adapter import LLaMA, LLaMAConfig, mark_only_adapter_as_trainable
+from lit_llama.adapter import LLaMA, LLaMAConfig, mark_only_adapter_as_trainable, adapter_state_from_state_dict
 from lit_llama.tokenizer import Tokenizer
-from lit_llama.utils import save_model_checkpoint
 from scripts.prepare_alpaca import generate_prompt
 from lightning.fabric.strategies import DeepSpeedStrategy
 
@@ -218,6 +218,27 @@ def load_datasets(data_dir: str = "data/alpaca"):
     train_data = torch.load(os.path.join(data_dir, "train.pt"))
     val_data = torch.load(os.path.join(data_dir, "test.pt"))
     return train_data, val_data
+
+
+def save_model_checkpoint(fabric, model, file_path):
+    file_path = Path(file_path)
+
+    if isinstance(fabric.strategy, DeepSpeedStrategy):
+        from deepspeed.utils.zero_to_fp32 import get_fp32_state_dict_from_zero_checkpoint
+
+        fabric.save(file_path, {"model": model})
+        fabric.barrier()
+        if fabric.global_rank == 0:
+            # Create a consolidated checkpoint with the same name next to the deepspeed checkpoint
+            # and only keep the adapter weights
+            state_dict = get_fp32_state_dict_from_zero_checkpoint(file_path)
+            state_dict = adapter_state_from_state_dict(state_dict)
+            torch.save(state_dict, file_path.with_suffix(".pth"))
+    else:
+        state_dict = adapter_state_from_state_dict(model.state_dict())
+        if fabric.global_rank == 0:
+            torch.save(state_dict, file_path)
+        fabric.barrier()
 
 
 if __name__ == "__main__":

--- a/finetune_adapter.py
+++ b/finetune_adapter.py
@@ -33,12 +33,12 @@ eval_interval = 600
 save_interval = 1000
 eval_iters = 100
 log_interval = 1
-devices = 1
+devices = 8
 
 # Hyperparameters
 learning_rate = 9e-3
 batch_size = 64 / devices
-micro_batch_size = 4
+micro_batch_size = 8
 gradient_accumulation_steps = batch_size // micro_batch_size
 epoch_size = 50000  # train dataset size
 num_epochs = 5

--- a/generate.py
+++ b/generate.py
@@ -107,7 +107,7 @@ def main(
         print("Loading model ...", file=sys.stderr)
         t0 = time.time()
         model = LLaMA.from_name(model_size)
-        checkpoint = torch.load(checkpoint_path)
+        checkpoint = torch.load(checkpoint_path, map_location=torch.device("cpu"))
         model.load_state_dict(checkpoint)
         print(f"Time to load model: {time.time() - t0:.02f} seconds.", file=sys.stderr)
 

--- a/generate.py
+++ b/generate.py
@@ -107,7 +107,7 @@ def main(
         print("Loading model ...", file=sys.stderr)
         t0 = time.time()
         model = LLaMA.from_name(model_size)
-        checkpoint = torch.load(checkpoint_path, map_location=torch.device("cpu"))
+        checkpoint = torch.load(checkpoint_path)
         model.load_state_dict(checkpoint)
         print(f"Time to load model: {time.time() - t0:.02f} seconds.", file=sys.stderr)
 

--- a/generate_adapter.py
+++ b/generate_adapter.py
@@ -68,12 +68,13 @@ def main(
         model = LLaMA(LLaMAConfig())  # TODO: Support different model sizes
 
         # 1. Load the pretrained weights
-        pretrained_checkpoint = torch.load(pretrained_path)
+        pretrained_checkpoint = torch.load(pretrained_path, map_location=torch.device("cpu"))
         model.load_state_dict(pretrained_checkpoint, strict=False)
+        
         # 2. Load the fine-tuned adapter weights
-        adapter_checkpoint = torch.load(adapter_path, map_location=torch.device("cpu"))
-
+        adapter_checkpoint = torch.load(adapter_path)
         model.load_state_dict(adapter_checkpoint, strict=False)
+        
         print(f"Time to load model: {time.time() - t0:.02f} seconds.", file=sys.stderr)
 
     model.eval()

--- a/lit_llama/adapter.py
+++ b/lit_llama/adapter.py
@@ -173,8 +173,6 @@ def mark_only_adapter_as_trainable(model: LLaMA) -> None:
         param.requires_grad = "adapter_wte" in name or "gating_factor" in name
 
 
-def adapter_state_dict(model: LLaMA) -> dict:
-    """Retrieve the model state dict with only the adapter weights for saving."""
-    return {
-        name: param for name, param in model.named_parameters() if "adapter_wte" in name or "gating_factor" in name
-    }
+def adapter_state_from_state_dict(state_dict: dict) -> dict:
+    """Returns the model state dict with only the adapter weights for saving."""
+    return {name: param for name, param in state_dict.items() if "adapter_wte" in name or "gating_factor" in name}

--- a/lit_llama/quantization.py
+++ b/lit_llama/quantization.py
@@ -13,6 +13,10 @@ warnings.filterwarnings(
 )
 warnings.filterwarnings(
     "ignore", 
+    message="MatMul8bitLt: inputs will be cast from torch.bfloat16 to float16 during quantization"
+)
+warnings.filterwarnings(
+    "ignore", 
     message="The installed version of bitsandbytes was compiled without GPU support. 8-bit optimizers and GPU quantization are unavailable."
 )
 

--- a/lit_llama/quantization.py
+++ b/lit_llama/quantization.py
@@ -35,9 +35,12 @@ if bnb is not None:
             # memory with float32 weights which could lead to OOM.
             self._quantize_weight(self.weight.data)
 
-        def _load_from_state_dict(self, local_state_dict, *args, **kwargs):
+        def _load_from_state_dict(self, local_state_dict, prefix, local_metadata, strict, *args, **kwargs):
+            keys = [name for name in local_state_dict.keys() if name.endswith("weight")]
+            if not keys:
+                return
             # There is only one key that ends with `*.weight`, the other one is the bias
-            weight_key = next(name for name in local_state_dict.keys() if name.endswith("weight"))
+            weight_key = keys[0]
 
             # Load the weight from the state dict and re-quantize it
             weight = local_state_dict.pop(weight_key)

--- a/lit_llama/quantization.py
+++ b/lit_llama/quantization.py
@@ -39,7 +39,7 @@ if bnb is not None:
             # memory with float32 weights which could lead to OOM.
             self._quantize_weight(self.weight.data)
 
-        def _load_from_state_dict(self, local_state_dict, prefix, local_metadata, strict, *args, **kwargs):
+        def _load_from_state_dict(self, local_state_dict, *args, **kwargs):
             keys = [name for name in local_state_dict.keys() if name.endswith("weight")]
             if not keys:
                 return

--- a/lit_llama/quantization.py
+++ b/lit_llama/quantization.py
@@ -40,11 +40,10 @@ if bnb is not None:
             self._quantize_weight(self.weight.data)
 
         def _load_from_state_dict(self, local_state_dict, *args, **kwargs):
-            keys = [name for name in local_state_dict.keys() if name.endswith("weight")]
-            if not keys:
-                return
             # There is only one key that ends with `*.weight`, the other one is the bias
-            weight_key = keys[0]
+            weight_key = next((name for name in local_state_dict.keys() if name.endswith("weight")), None)
+            if weight_key is None:
+                return
 
             # Load the weight from the state dict and re-quantize it
             weight = local_state_dict.pop(weight_key)


### PR DESCRIPTION
- Save only adapter weights for smaller checkpoints and easier sharing: This requires a bit of inefficient hacking for the case we are running finetuning with multi-gpu deepspeed. We should look for ways to make this simpler in the future.
- Load adapter weights separately for inference: This requires a small fix for our custom bnb.Linear layer. 

Addresses https://github.com/Lightning-AI/lit-llama/pull/149#discussion_r1169028988

Note: LoRA finetuning already has this covered.