### PR TITLE
Add lazyload from torchhacks

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -8,7 +8,7 @@ import lightning as L
 import torch
 
 from lit_llama import LLaMA, Tokenizer
-from lit_llama.utils import EmptyInitOnDevice
+from lit_llama.utils import EmptyInitOnDevice, lazy_load
 
 
 @torch.no_grad()
@@ -101,15 +101,16 @@ def main(
     fabric = L.Fabric(accelerator="cuda", devices=1)
     dtype = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float32
 
+    print("Loading model ...", file=sys.stderr)
+    t0 = time.time()
     with EmptyInitOnDevice(
         device=fabric.device, dtype=dtype, quantization_mode=quantize
     ):
-        print("Loading model ...", file=sys.stderr)
-        t0 = time.time()
         model = LLaMA.from_name(model_size)
-        checkpoint = torch.load(checkpoint_path)
-        model.load_state_dict(checkpoint)
-        print(f"Time to load model: {time.time() - t0:.02f} seconds.", file=sys.stderr)
+
+    checkpoint = lazy_load(checkpoint_path)
+    model.load_state_dict(checkpoint)
+    print(f"Time to load model: {time.time() - t0:.02f} seconds.", file=sys.stderr)
 
     model.eval()
     model = fabric.setup_module(model)

--- a/generate_lora.py
+++ b/generate_lora.py
@@ -10,7 +10,7 @@ import torch
 from generate import generate
 from lit_llama import Tokenizer, LLaMA, LLaMAConfig
 from lit_llama.lora import lora
-from lit_llama.utils import EmptyInitOnDevice
+from lit_llama.utils import EmptyInitOnDevice, lazy_load
 from scripts.prepare_alpaca import generate_prompt
 
 lora_r = 8
@@ -74,22 +74,22 @@ def main(
         raise ValueError(f"{dtype} is not a valid dtype.")
     dtype = dt
 
+    print("Loading model ...", file=sys.stderr)
+    t0 = time.time()
     with EmptyInitOnDevice(
         device=fabric.device, dtype=dtype, quantization_mode=quantize
     ), lora(r=lora_r, alpha=lora_alpha, dropout=lora_dropout, enabled=True):
-        print("Loading model ...", file=sys.stderr)
-        t0 = time.time()
         model = LLaMA(LLaMAConfig())  # TODO: Support different model sizes
 
-        # 1. Load the pretrained weights
-        pretrained_checkpoint = torch.load(pretrained_path)
-        model.load_state_dict(pretrained_checkpoint, strict=False)
+    # 1. Load the pretrained weights
+    pretrained_checkpoint = lazy_load(pretrained_path)
+    model.load_state_dict(pretrained_checkpoint, strict=False)
 
-        # 2. Load the fine-tuned LoRA weights
-        lora_checkpoint = torch.load(lora_path)
-        model.load_state_dict(lora_checkpoint, strict=False)
+    # 2. Load the fine-tuned LoRA weights
+    lora_checkpoint = lazy_load(lora_path)
+    model.load_state_dict(lora_checkpoint, strict=False)
 
-        print(f"Time to load model: {time.time() - t0:.02f} seconds.", file=sys.stderr)
+    print(f"Time to load model: {time.time() - t0:.02f} seconds.", file=sys.stderr)
 
     model.eval()
     model = fabric.setup_module(model)

--- a/lit_llama/utils.py
+++ b/lit_llama/utils.py
@@ -206,6 +206,10 @@ class NotYetLoadedTensor:
             return getattr(self.metatensor, name)
         if name in {"size"}:
             return getattr(self.metatensor, name)
+        # materializing with contiguous is needed for quantization
+        if name in {"contiguous"}:
+            return getattr(self._load_tensor(), name)
+
         raise AttributeError(f"{type(self)} does not have {name}")
 
     def __repr__(self):

--- a/lit_llama/utils.py
+++ b/lit_llama/utils.py
@@ -2,6 +2,9 @@
 
 import functools
 from pathlib import Path
+import zipfile
+import pickle
+import warnings
 
 import torch
 import torch.utils._device
@@ -50,6 +53,7 @@ class EmptyInitOnDevice(torch.overrides.TorchFunctionMode):
             dtype: `torch.dtype` to work with
             quantization_mode: optional string, quantization mode to work with, default `None`.
                  Available modes: `llm.int8` bitsnbytes LLM.int8 quantization (only on GPU)
+                                  `qptq.int4`, `gptq.int8`: GPTQ pre-quantized models
 
         Example::
             with EmptyInitOnDevice("cuda", dtype=torch.bfloat16):
@@ -105,3 +109,126 @@ class EmptyInitOnDevice(torch.overrides.TorchFunctionMode):
         ):
             kwargs["dtype"] = self.dtype
         return func(*args, **kwargs)
+
+
+
+# this is taken from torchhacks https://github.com/lernapparat/torchhacks
+
+class NotYetLoadedTensor:
+    def __init__(self, metatensor, archiveinfo, storageinfo, rebuild_args):
+        self.metatensor = metatensor
+        self.archiveinfo = archiveinfo
+        self.storageinfo = storageinfo
+        self.rebuild_args = rebuild_args
+
+    @classmethod
+    def rebuild(
+        cls,
+        storage,
+        storage_offset,
+        size,
+        stride,
+        requires_grad,
+        backward_hooks,
+        metadata=None,
+        archiveinfo=None,
+    ):
+        rebuild_args = (
+            storage_offset,
+            size,
+            stride,
+            requires_grad,
+            backward_hooks,
+            metadata,
+        )
+        metatensor = torch._utils._rebuild_tensor_v2(
+            storage,
+            storage_offset,
+            size,
+            stride,
+            requires_grad,
+            backward_hooks,
+            metadata,
+        )
+        storageinfo = storage.archiveinfo
+        return NotYetLoadedTensor(metatensor, archiveinfo, storageinfo, rebuild_args)
+
+    def _load_tensor(self):
+        # we could / should try to lean heavier on PyTorch's reader
+        name, storage_cls, fn, device, size = self.storageinfo
+        buffer = self.archiveinfo.zipfile.read(
+            str(self.archiveinfo.prefix / "data" / fn)
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            storage = storage_cls.from_buffer(buffer, "native")
+        tensor = torch._utils._rebuild_tensor_v2(storage, *self.rebuild_args)
+        return tensor
+
+    @classmethod
+    def __torch_function__(cls, func, types, args=(), kwargs=None):
+        if kwargs is None:
+            kwargs = {}
+        loaded_args = [
+            (a._load_tensor() if isinstance(a, NotYetLoadedTensor) else a) for a in args
+        ]
+        res = func(*loaded_args, **kwargs)
+        # gc.collect would be costly here, maybe do it optionally
+        return res
+
+    def __getattr__(self, name):
+        # properties
+        ## TODO: device, is_...??
+        ## TODO: mH, mT, H, T, data, imag, real
+        ## name ???
+        if name in {
+            "dtype",
+            "grad",
+            "grad_fn",
+            "layout",
+            "names",
+            "ndim",
+            "output_nr",
+            "requires_grad",
+            "retains_grad",
+            "shape",
+            "volatile",
+        }:
+            return getattr(self.metatensor, name)
+        if name in {"size"}:
+            return getattr(self.metatensor, name)
+        raise AttributeError(f"{type(self)} does not have {name}")
+
+    def __repr__(self):
+        return f"NotYetLoadedTensor({repr(self.metatensor)})"
+
+
+class LazyLoadingUnpickler(pickle.Unpickler):
+    def __init__(self, file, zipfile, prefix):
+        super().__init__(file)
+        self.zipfile = zipfile
+        self.prefix = prefix
+
+    def find_class(self, module, name):
+        if module == "torch._utils" and name == "_rebuild_tensor_v2":
+            res = super().find_class(module, name)
+            return functools.partial(NotYetLoadedTensor.rebuild, archiveinfo=self)
+        return super().find_class(module, name)
+
+    def persistent_load(self, pid):
+        name, cls, fn, device, size = pid
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            s = torch.storage.TypedStorage(dtype=cls().dtype, device="meta")
+        s.archiveinfo = pid
+        return s
+
+
+def lazy_load(fn):
+    zf = zipfile.ZipFile(fn)
+    nl = zf.namelist()
+    prefix = Path(Path(nl[0]).parts[0])
+    with zf.open(str(prefix / "data.pkl"), "r") as pkl:
+        mup = LazyLoadingUnpickler(pkl, zf, prefix)
+        sd = mup.load()
+    return sd

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -70,6 +70,7 @@ def test_main(tmp_path, monkeypatch):
     monkeypatch.setattr(generate.LLaMA, "from_name", model_mock)
     load_mock = Mock()
     monkeypatch.setattr(generate.torch, "load", load_mock)
+    monkeypatch.setattr(generate, "lazy_load", load_mock)
     tokenizer_mock = Mock()
     tokenizer_mock.return_value.encode.return_value = torch.tensor([[1, 2, 3]])
     tokenizer_mock.return_value.decode.return_value = "foo bar baz"


### PR DESCRIPTION
...and use it in generate.

Drawback (7B model and default settings):
```
  Before: Time to load model: 4.01 seconds.
  After:  Time to load model: 4.14 seconds.
```

Advantage (from time -v):
```
  Before: Maximum resident set size (kbytes): 14103952
  After:  Maximum resident set size (kbytes): 1179236
```

The other thing here is copying vs. using torchhacks as a dependency, I went with the former for now, either way is OK with me.
Obviously, this depends on PyTorch internals more than other bits.

Are there places where we do not want to use lazy_load for the model loading? What about the datasets in `finetune*.py`?
