### PR TITLE
Fix generate.py missing batch dimension for model 

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -47,8 +47,8 @@ def generate(
         idx_cond = idx_cond if T <= max_seq_length else idx_cond[-max_seq_length:]
 
         # forward
-        logits = model(idx_cond)
-        logits = logits[-1] / temperature
+        logits = model(idx_cond.view(1, -1))
+        logits = logits[0, -1] / temperature
 
         # optionally crop the logits to only the top k options
         if top_k is not None:

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -6,7 +6,6 @@ from io import StringIO
 from pathlib import Path
 from unittest import mock
 from unittest.mock import Mock, call, ANY
-from lit_llama.model import LLaMA, LLaMAConfig
 
 import torch
 
@@ -23,6 +22,8 @@ def load_generate_script():
 
 
 def test_generate():
+    from lit_llama.model import LLaMA, LLaMAConfig
+
     generate = load_generate_script()
 
     T, C = 5, 3

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -22,9 +22,9 @@ def load_generate_script():
 
 
 def test_generate():
-    from lit_llama.model import LLaMA, LLaMAConfig
-
     generate = load_generate_script()
+
+    from lit_llama.model import LLaMA, LLaMAConfig
 
     T, C = 5, 3
     logits = torch.randn(T, C)

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -6,6 +6,7 @@ from io import StringIO
 from pathlib import Path
 from unittest import mock
 from unittest.mock import Mock, call, ANY
+from lit_llama.model import LLaMA, LLaMAConfig
 
 import torch
 
@@ -28,7 +29,8 @@ def test_generate():
     logits = torch.randn(T, C)
     input_idx = torch.randint(10, size=(T,))
 
-    model = Mock(return_value=logits)
+    config = LLaMAConfig(block_size=128, vocab_size=16, n_layer=1, n_head=4, n_embd=8)
+    model = LLaMA(config)
     max_new_tokens = 20
 
     multinomial_results = []


### PR DESCRIPTION
Fixes #162

```bash
python generate.py
```

```
  File "/home/adrian/.conda/envs/lit-llama/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1501, in _call_impl
    return forward_call(*args, **kwargs)
  File "/home/adrian/repositories/lightning-llama/lit_llama/model.py", line 59, in forward
    _, t = idx.size()
ValueError: not enough values to unpack (expected 2, got 1)
```

cc @carmocca 