### PR TITLE
Make `adapter.LLaMA.from_name` available

### DIFF
--- a/lit_llama/adapter.py
+++ b/lit_llama/adapter.py
@@ -142,8 +142,6 @@ def mark_only_adapter_as_trainable(model: LLaMA) -> None:
         param.requires_grad = "adapter_wte" in name or "gating_factor" in name
 
 
-def adapter_state_dict(model: LLaMA) -> dict:
-    """Retrieve the model state dict with only the adapter weights for saving."""
-    return {
-        name: param for name, param in model.named_parameters() if "adapter_wte" in name or "gating_factor" in name
-    }
+def adapter_state_from_state_dict(state_dict: dict) -> dict:
+    """Returns the model state dict with only the adapter weights for saving."""
+    return {name: param for name, param in state_dict.items() if "adapter_wte" in name or "gating_factor" in name}

--- a/lit_llama/adapter.py
+++ b/lit_llama/adapter.py
@@ -135,6 +135,10 @@ class LLaMA(llama.LLaMA):
             )
         )
 
+    @classmethod
+    def from_name(cls, name: str):
+        return cls(LLaMAConfig.from_name(name))
+
 
 def mark_only_adapter_as_trainable(model: LLaMA) -> None:
     """Sets `requires_grad=False` for all non-adapter weights."""

--- a/lit_llama/adapter.py
+++ b/lit_llama/adapter.py
@@ -10,18 +10,12 @@ from dataclasses import dataclass
 import torch
 import torch.nn as nn
 from torch.nn import functional as F
+import lit_llama.model as llama
 from lit_llama.model import build_rope_cache, apply_rope, RMSNorm, MLP
 
 
 @dataclass
-class LLaMAConfig:
-    # Default configuration is the 7B model
-    block_size: int = 4096
-    vocab_size: int = 32000
-    n_layer: int = 32
-    n_head: int = 32
-    n_embd: int = 4096
-
+class LLaMAConfig(llama.LLaMAConfig):
     adapter_prompt_length: int = 10
     adapter_start_layer: int = 2
 
@@ -122,12 +116,12 @@ class Block(nn.Module):
         return x
 
 
-class LLaMA(nn.Module):
+class LLaMA(llama.LLaMA):
     """The implementation is identical to `lit_llama.model.LLaMA` with the exception that
     the `Block` saves the layer index and passes it down to the attention layer."""
 
     def __init__(self, config: LLaMAConfig) -> None:
-        super().__init__()
+        nn.Module.__init__(self)
         assert config.vocab_size is not None
         assert config.block_size is not None
         self.config = config
@@ -141,31 +135,6 @@ class LLaMA(nn.Module):
             )
         )
 
-    def _init_weights(self, module: nn.Module) -> None:
-        if isinstance(module, nn.Linear):
-            torch.nn.init.normal_(module.weight, mean=0.0, std=0.02 / math.sqrt(2 * self.config.n_layer))
-        elif isinstance(module, nn.Embedding):
-            torch.nn.init.normal_(module.weight, mean=0.0, std=0.02 / math.sqrt(2 * self.config.n_layer))
-
-    def forward(self, idx: torch.Tensor) -> torch.Tensor:
-        _, t = idx.size()
-        assert (
-            t <= self.config.block_size
-        ), f"Cannot forward sequence of length {t}, block size is only {self.config.block_size}"
-
-        # forward the LLaMA model itself
-        x = self.transformer.wte(idx)  # token embeddings of shape (b, t, n_embd)
-
-        for block in self.transformer.h:
-            x = block(x)
-
-        x = self.transformer.ln_f(x)
-
-        logits = self.lm_head(x)  # (b, t, vocab_size)
-
-        return logits
-
-
 
 def mark_only_adapter_as_trainable(model: LLaMA) -> None:
     """Sets `requires_grad=False` for all non-adapter weights."""
@@ -173,6 +142,8 @@ def mark_only_adapter_as_trainable(model: LLaMA) -> None:
         param.requires_grad = "adapter_wte" in name or "gating_factor" in name
 
 
-def adapter_state_from_state_dict(state_dict: dict) -> dict:
-    """Returns the model state dict with only the adapter weights for saving."""
-    return {name: param for name, param in state_dict.items() if "adapter_wte" in name or "gating_factor" in name}
+def adapter_state_dict(model: LLaMA) -> dict:
+    """Retrieve the model state dict with only the adapter weights for saving."""
+    return {
+        name: param for name, param in model.named_parameters() if "adapter_wte" in name or "gating_factor" in name
+    }

--- a/lit_llama/model.py
+++ b/lit_llama/model.py
@@ -22,14 +22,14 @@ class LLaMAConfig:
 
     @classmethod
     def from_name(cls, name: str) -> Self:
-        return llama_configs[name]
+        return cls(**llama_configs[name])
 
 
 llama_configs = {
-    "7B": LLaMAConfig(n_layer=32, n_head=32, n_embd=4096),
-    "13B": LLaMAConfig(n_layer=40, n_head=40, n_embd=5120),
-    "30B": LLaMAConfig(n_layer=60, n_head=52, n_embd=6656),
-    "65B": LLaMAConfig(n_layer=80, n_head=64, n_embd=8192),
+    "7B": dict(n_layer=32, n_head=32, n_embd=4096),
+    "13B": dict(n_layer=40, n_head=40, n_embd=5120),
+    "30B": dict(n_layer=60, n_head=52, n_embd=6656),
+    "65B": dict(n_layer=80, n_head=64, n_embd=8192),
 }
 
 

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -1,8 +1,10 @@
 import torch
 from dataclasses import asdict
 import pytest
+import sys
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="EmptyInitOnDevice on CPU not working for Windows.")
 @pytest.mark.parametrize("model_size", ["7B", "13B", "30B", "65B"])
 def test_config_identical(model_size, lit_llama):
     import lit_llama.adapter as llama_adapter

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -1,0 +1,21 @@
+import torch
+from dataclasses import asdict
+
+
+def test_config_identical(lit_llama):
+    import lit_llama.adapter as llama_adapter
+    import lit_llama.model as llama
+    from lit_llama.utils import EmptyInitOnDevice
+
+    llama_config = asdict(llama.LLaMAConfig())
+    adapter_config = asdict(llama_adapter.LLaMAConfig())
+
+    del adapter_config["adapter_prompt_length"]
+    del adapter_config["adapter_start_layer"]
+    assert adapter_config == llama_config
+
+    with EmptyInitOnDevice(device=torch.device("cpu")):
+        llama_model = llama.LLaMA.from_name("7B")
+        adapter_model = llama_adapter.LLaMA.from_name("7B")
+
+        assert llama_model.lm_head.weight.shape == adapter_model.lm_head.weight.shape

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -1,21 +1,22 @@
 import torch
 from dataclasses import asdict
+import pytest
 
 
-def test_config_identical(lit_llama):
+@pytest.mark.parametrize("model_size", ["7B", "13B", "30B", "65B"])
+def test_config_identical(model_size, lit_llama):
     import lit_llama.adapter as llama_adapter
     import lit_llama.model as llama
     from lit_llama.utils import EmptyInitOnDevice
 
-    llama_config = asdict(llama.LLaMAConfig())
-    adapter_config = asdict(llama_adapter.LLaMAConfig())
+    llama_config = asdict(llama.LLaMAConfig.from_name(model_size))
+    adapter_config = asdict(llama_adapter.LLaMAConfig.from_name(model_size))
 
     del adapter_config["adapter_prompt_length"]
     del adapter_config["adapter_start_layer"]
     assert adapter_config == llama_config
 
-    with EmptyInitOnDevice(device=torch.device("cpu")):
-        llama_model = llama.LLaMA.from_name("7B")
-        adapter_model = llama_adapter.LLaMA.from_name("7B")
-
+    with EmptyInitOnDevice():
+        llama_model = llama.LLaMA.from_name(model_size)
+        adapter_model = llama_adapter.LLaMA.from_name(model_size)
         assert llama_model.lm_head.weight.shape == adapter_model.lm_head.weight.shape


### PR DESCRIPTION
We initially didn't expect that we would finetune the bigger models with adapters as well, so we only included the default 7B config. 

The PR #160 wants to call `LLaMA.from_name` but it is not available for the adapter implementation. This PR extends the existing config to enable this.