### PR TITLE
Compute the generation time per sample

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -126,9 +126,8 @@ def main(
     encoded_prompt = tokenizer.encode(prompt, bos=True, eos=False, device=fabric.device)
 
     L.seed_everything(1234)
-    t0 = time.perf_counter()
-
-    for _ in range(num_samples):
+    for i in range(num_samples):
+        t0 = time.perf_counter()
         y = generate(
             model,
             encoded_prompt,
@@ -137,10 +136,9 @@ def main(
             temperature=temperature,
             top_k=top_k,
         )
+        t = time.perf_counter() - t0
         print(tokenizer.decode(y))
-
-    t = time.perf_counter() - t0
-    print(f"\n\nTime for inference: {t:.02f} sec total, {num_samples * max_new_tokens / t:.02f} tokens/sec", file=sys.stderr)
+        print(f"Time for inference {i}: {t:.02f} sec total, {max_new_tokens / t:.02f} tokens/sec", file=sys.stderr)
     if fabric.device.type == "cuda":
         print(f"Memory used: {torch.cuda.max_memory_reserved() / 1e9:.02f} GB", file=sys.stderr)
 

--- a/generate.py
+++ b/generate.py
@@ -138,7 +138,7 @@ def main(
         )
         t = time.perf_counter() - t0
         print(tokenizer.decode(y))
-        print(f"Time for inference {i}: {t:.02f} sec total, {max_new_tokens / t:.02f} tokens/sec", file=sys.stderr)
+        print(f"Time for inference {i + 1}: {t:.02f} sec total, {max_new_tokens / t:.02f} tokens/sec", file=sys.stderr)
     if fabric.device.type == "cuda":
         print(f"Memory used: {torch.cuda.max_memory_reserved() / 1e9:.02f} GB", file=sys.stderr)
 


### PR DESCRIPTION
With compilation-based strategies or using `torch.compile`, the generation time might vary a lot across generations. The current implementation computes the total duration which is not that useful in this context.

This PR proposes to print the generation time per generation.

Right now, it interleaves the generation with the time. If you prefer, I can save either of them into a list and flush them together at the end.

I can update the other generation scripts once the design is decided.