### PR TITLE
Add simple test asserting LLaMA can torch.compile

### DIFF
--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -177,3 +177,20 @@ def test_adapter_parity(orig_llama_adapter):
     expected = orig_llama_model(token_sample, 0)
     out = llama_model(token_sample)
     assert torch.allclose(out, expected)
+
+
+def test_model_compile(lit_llama):
+    llama_config = lit_llama.LLaMAConfig(
+        block_size=8,
+        vocab_size=8,
+        n_layer=2,
+        n_head=2,
+        n_embd=4,
+    )
+    model = lit_llama.LLaMA(llama_config)
+    model.apply(model._init_weights)
+
+    model = torch.compile(model)
+
+    sample = torch.ones(4, model.config.block_size, dtype=torch.int64)
+    _ = model(sample)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -181,7 +181,7 @@ def test_adapter_parity(orig_llama_adapter):
     assert torch.allclose(out, expected)
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="torch.compile not supported on Windows")
+@pytest.mark.skipif(sys.platform in ("win32", "darwin"), reason="torch.compile not supported on this platform")
 def test_model_compile(lit_llama):
     llama_config = lit_llama.LLaMAConfig(
         block_size=8,

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -192,5 +192,6 @@ def test_model_compile(lit_llama):
 
     model = torch.compile(model)
 
-    sample = torch.ones(4, model.config.block_size, dtype=torch.int64)
-    _ = model(sample)
+    sample = torch.randint(model.config.vocab_size, size=(2, model.config.block_size), dtype=torch.int64)
+    for _ in range(3):
+        _ = model(sample)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,5 +1,7 @@
 import torch
 import pytest
+import sys
+
 
 def copy_mlp(llama_mlp, orig_llama_mlp) -> None:
     orig_llama_mlp.w1.weight.copy_(llama_mlp.c_fc1.weight)
@@ -179,6 +181,7 @@ def test_adapter_parity(orig_llama_adapter):
     assert torch.allclose(out, expected)
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="torch.compile not supported on Windows")
 def test_model_compile(lit_llama):
     llama_config = lit_llama.LLaMAConfig(
         block_size=8,


### PR DESCRIPTION
Adds a simple test now that LLaMA can `torch.compile`. 
Scripts will be modified to use torch.compile in #103 