### PR TITLE
Fixes DATA_FILE_NAME with updated from DATA_FILE

### DIFF
--- a/scripts/prepare_alpaca.py
+++ b/scripts/prepare_alpaca.py
@@ -15,7 +15,7 @@ from tqdm import tqdm
 
 
 DATA_FILE = "https://raw.githubusercontent.com/tloen/alpaca-lora/main/alpaca_data_cleaned_archive.json"
-DATA_FILE_NAME = "alpaca_data_cleaned.json"
+DATA_FILE_NAME = "alpaca_data_cleaned_archive.json"
 IGNORE_INDEX = -1
 
 


### PR DESCRIPTION
This pull request addresses issue #182 by updating the value of the DATA_FILE_NAME variable in the prepare_alpaca.py script to "alpaca_data_cleaned_archive.json", which is the correct file name. The change is a simple modification to a single line of code.