### PR TITLE
Fix .eval() merging of LoRA weights

### DIFF
--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -41,10 +41,21 @@ def test_lora_merge_unmerge(lit_llama):
     # the weight remains unchanged (only lora A and B change)
     assert torch.equal(model.transformer.h[0].attn.c_attn.weight, initial_weight)
 
-    # merge and then unmerge should neutralize themselves
+    # 'merge' and then 'unmerge' should neutralize themselves
     weight_before = model.transformer.h[0].attn.c_attn.weight.clone()
     model.eval()
     assert not torch.equal(model.transformer.h[0].attn.c_attn.weight, weight_before)
     model.train()
     # note: numerically, `W + (A * B) - (A * B) == W` does not hold exactly
     assert torch.allclose(model.transformer.h[0].attn.c_attn.weight, weight_before)
+
+    # calling eval/train multiple times in a row should not merge/unmerge multiple times
+    model.eval()
+    weight_after = model.transformer.h[0].attn.c_attn.weight.clone()
+    model.eval()
+    model.eval()
+    assert torch.equal(model.transformer.h[0].attn.c_attn.weight, weight_after)
+   
+    # model.train()
+    # # note: numerically, `W + (A * B) - (A * B) == W` does not hold exactly
+    # assert torch.allclose(model.transformer.h[0].attn.c_attn.weight, weight_before)

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -1,3 +1,4 @@
+import torch
 
 
 def test_lora_layer_replacement(lit_llama):
@@ -16,3 +17,34 @@ def test_lora_layer_replacement(lit_llama):
 
     assert isinstance(model.transformer.h[0].attn, LoRACausalSelfAttention)
     assert isinstance(model.transformer.h[1].attn, LoRACausalSelfAttention)
+
+
+def test_lora_merge_unmerge(lit_llama):
+    from lit_llama.lora import lora, mark_only_lora_as_trainable
+    from lit_llama.model import LLaMA, LLaMAConfig
+    
+    config = LLaMAConfig(n_layer=1, n_head=2, n_embd=8, block_size=8, vocab_size=8)
+
+    with lora(r=8, alpha=8, dropout=0.1):
+        model = LLaMA(config)
+    
+    initial_weight = model.transformer.h[0].attn.c_attn.weight.clone()
+    model.train()
+    assert torch.equal(model.transformer.h[0].attn.c_attn.weight, initial_weight)
+
+    # perform an update to the LoRA weights
+    mark_only_lora_as_trainable(model)
+    optimizer = torch.optim.SGD(model.parameters(), lr=1.0)
+    model(torch.randint(0, 8, size=(2, 4), dtype=torch.int64)).sum().backward()
+    optimizer.step()
+    optimizer.zero_grad()
+    # the weight remains unchanged (only lora A and B change)
+    assert torch.equal(model.transformer.h[0].attn.c_attn.weight, initial_weight)
+
+    # merge and then unmerge should neutralize themselves
+    weight_before = model.transformer.h[0].attn.c_attn.weight.clone()
+    model.eval()
+    assert not torch.equal(model.transformer.h[0].attn.c_attn.weight, weight_before)
+    model.train()
+    # note: numerically, `W + (A * B) - (A * B) == W` does not hold exactly
+    assert torch.allclose(model.transformer.h[0].attn.c_attn.weight, weight_before)

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -51,11 +51,14 @@ def test_lora_merge_unmerge(lit_llama):
 
     # calling eval/train multiple times in a row should not merge/unmerge multiple times
     model.eval()
+    assert model.transformer.h[0].attn.c_attn.merged
     weight_after = model.transformer.h[0].attn.c_attn.weight.clone()
     model.eval()
     model.eval()
     assert torch.equal(model.transformer.h[0].attn.c_attn.weight, weight_after)
-   
-    # model.train()
-    # # note: numerically, `W + (A * B) - (A * B) == W` does not hold exactly
-    # assert torch.allclose(model.transformer.h[0].attn.c_attn.weight, weight_before)
+    model.train()
+    assert not model.transformer.h[0].attn.c_attn.merged
+    weight_after = model.transformer.h[0].attn.c_attn.weight.clone()
+    model.train()
+    model.train()
+    assert torch.equal(model.transformer.h[0].attn.c_attn.weight, weight_after)


### PR DESCRIPTION
When we adapted the LoRA layer implementation from https://github.com/microsoft/LoRA/ we also inherited a bug in the train() and eval() methods that are meant to merge and unmerge the LoRA weights.

This was already pointed out by users on their side https://github.com/microsoft/LoRA/issues/34 but was never addressed.
The problem is that they implement the eval() method, which is dead code and never gets called. Because internally in `nn.Module.eval()`, it calls `nn.Module.train(False)` and thus only ever the train() method gets called recursively on all submodules.

