### PR TITLE
Use the new `Fabric.init_module()` for finetuning

### DIFF
--- a/finetune_adapter.py
+++ b/finetune_adapter.py
@@ -86,7 +86,6 @@ def main(
         # strict=False because missing keys due to adapter weights not containted in state dict
         model.load_state_dict(checkpoint, strict=False)
 
-    print(torch.cuda.max_memory_allocated() // 1e6)
     mark_only_adapter_as_trainable(model)
 
     num_params = sum([p.numel() for p in model.parameters() if p.requires_grad])

--- a/finetune_adapter.py
+++ b/finetune_adapter.py
@@ -82,10 +82,7 @@ def main(
     checkpoint = torch.load(pretrained_path)
 
     with fabric.init_module():
-    # with fabric.device:
-        # torch.set_default_tensor_type(torch.HalfTensor)
-        model = LLaMA(config) # .bfloat16()
-        # torch.set_default_tensor_type(torch.FloatTensor)
+        model = LLaMA(config)
         # strict=False because missing keys due to adapter weights not containted in state dict
         model.load_state_dict(checkpoint, strict=False)
 

--- a/finetune_adapter.py
+++ b/finetune_adapter.py
@@ -62,7 +62,7 @@ def main(
         accelerator="cuda", 
         devices=devices, 
         strategy=(DeepSpeedStrategy(config=ds_config) if devices > 1 else "auto"), 
-        precision="bf16-mixed",
+        precision="bf16-true",
     )
     fabric.launch()
     fabric.seed_everything(1337 + fabric.global_rank)
@@ -81,13 +81,15 @@ def main(
         )
     checkpoint = torch.load(pretrained_path)
 
-    with fabric.device:
-        torch.set_default_tensor_type(torch.HalfTensor)
-        model = LLaMA(config).bfloat16()
-        torch.set_default_tensor_type(torch.FloatTensor)
+    with fabric.init_module():
+    # with fabric.device:
+        # torch.set_default_tensor_type(torch.HalfTensor)
+        model = LLaMA(config) # .bfloat16()
+        # torch.set_default_tensor_type(torch.FloatTensor)
         # strict=False because missing keys due to adapter weights not containted in state dict
         model.load_state_dict(checkpoint, strict=False)
-    
+
+    print(torch.cuda.max_memory_allocated() // 1e6)
     mark_only_adapter_as_trainable(model)
 
     num_params = sum([p.numel() for p in model.parameters() if p.requires_grad])

--- a/finetune_lora.py
+++ b/finetune_lora.py
@@ -62,8 +62,6 @@ def main(
         # strict=False because missing keys due to LoRA weights not contained in checkpoint state
         model.load_state_dict(checkpoint, strict=False)
     
-    print(torch.cuda.max_memory_allocated() // 1e6)
-    
     mark_only_lora_as_trainable(model)
 
     optimizer = torch.optim.AdamW(model.parameters(), lr=learning_rate)

--- a/finetune_lora.py
+++ b/finetune_lora.py
@@ -43,7 +43,7 @@ def main(
     out_dir: str = "out/lora/alpaca",
 ):
 
-    fabric = L.Fabric(accelerator="cuda", devices=1, precision="bf16-mixed")
+    fabric = L.Fabric(accelerator="cuda", devices=1, precision="bf16-true")
     fabric.launch()
     fabric.seed_everything(1337 + fabric.global_rank)
 
@@ -57,12 +57,14 @@ def main(
 
     checkpoint = torch.load(pretrained_path)
 
-    with fabric.device, lora(r=lora_r, alpha=lora_alpha, dropout=lora_dropout, enabled=True):
-        torch.set_default_tensor_type(torch.HalfTensor)
-        model = LLaMA(config).bfloat16()
-        torch.set_default_tensor_type(torch.FloatTensor)
+    with fabric.init_module(), lora(r=lora_r, alpha=lora_alpha, dropout=lora_dropout, enabled=True):
+        # torch.set_default_tensor_type(torch.HalfTensor)
+        model = LLaMA(config)  # .bfloat16()
+        # torch.set_default_tensor_type(torch.FloatTensor)
         # strict=False because missing keys due to LoRA weights not contained in checkpoint state
-        model.load_state_dict(checkpoint, strict=False) 
+        model.load_state_dict(checkpoint, strict=False)
+    
+    print(torch.cuda.max_memory_allocated() // 1e6)
     
     mark_only_lora_as_trainable(model)
 

--- a/finetune_lora.py
+++ b/finetune_lora.py
@@ -58,9 +58,7 @@ def main(
     checkpoint = torch.load(pretrained_path)
 
     with fabric.init_module(), lora(r=lora_r, alpha=lora_alpha, dropout=lora_dropout, enabled=True):
-        # torch.set_default_tensor_type(torch.HalfTensor)
-        model = LLaMA(config)  # .bfloat16()
-        # torch.set_default_tensor_type(torch.FloatTensor)
+        model = LLaMA(config)
         # strict=False because missing keys due to LoRA weights not contained in checkpoint state
         model.load_state_dict(checkpoint, strict=False)
     


### PR DESCRIPTION
This feature is only available on Lightning master. Our requirements file already requires lightning master, but users with lightning 2.0 will get an error. If we are worried that users get confused, we should hold off merging this PR until Lightning 2.1 released. 

Note, Fabric.init_module() can't yet be nicely integrated with our train.py because we have to work around [a bug in FSDP+meta device](https://github.com/pytorch/pytorch/issues/90465) (I'm looking into that). In the future, we will also be able to integrate it with our generate.py scripts, but we need to expose a flag for making the weights empty (like EmptyInitOnDevice from lit_llama.utils) to replicate the desired behavior there.