### PR TITLE
Add missing save_model_checkpoint import

### DIFF
--- a/finetune_full.py
+++ b/finetune_full.py
@@ -17,6 +17,7 @@ from torch.distributed.fsdp.wrap import transformer_auto_wrap_policy
 from generate import generate
 from lit_llama.model import Block, LLaMA, LLaMAConfig
 from lit_llama.tokenizer import Tokenizer
+from lit_llama.utils import save_model_checkpoint
 from scripts.prepare_alpaca import generate_prompt
 
 


### PR DESCRIPTION
## Changes Made

I added the following line to the `finetune_full.py` file:

```python
from lit_llama.utils import save_model_checkpoint
```