### PR TITLE
Set up dataloaders in redpajama training script

### DIFF
--- a/train_redpajama.py
+++ b/train_redpajama.py
@@ -135,10 +135,9 @@ def train(
 
         t0 = time.time()
 
-        input_ids, targets = get_batch(
-            fabric, train_data, block_size=model.config.block_size
-        )
-
+        input_ids = train_data[:, 0 : model.config.block_size].contiguous()
+        targets = train_data[:, 1 : model.config.block_size + 1].contiguous()
+        
         is_accumulating = (iter_num + 1) % grad_accum_steps == 0
 
         with fabric.no_backward_sync(model, enabled=is_accumulating):
@@ -190,11 +189,8 @@ def validate(
     model.eval()
     losses = torch.zeros(eval_iters)
     for k, val_data in enumerate(val_dataloader):
-        input_ids, targets = get_batch(
-            fabric,
-            val_data,
-            block_size=model.config.block_size,  # type: ignore[union-attr,arg-type]
-        )
+        input_ids = val_data[:, 0 : model.config.block_size].contiguous()
+        targets = val_data[:, 1 : model.config.block_size + 1].contiguous()
         logits = model(input_ids)
         loss = torch.nn.functional.cross_entropy(
             logits.view(-1, logits.size(-1)), targets.view(-1), ignore_index=-1
@@ -262,14 +258,6 @@ def create_dataloaders(
         else None
     )
     return train_dataloader, val_dataloader
-
-
-def get_batch(
-    fabric: L.Fabric, data: np.ndarray, block_size: int
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    x = data[:, 0 : block_size].contiguous()
-    y = data[:, 1 : block_size + 1].contiguous()
-    return x, y
 
 
 # learning rate decay scheduler (cosine with warmup)

--- a/train_redpajama.py
+++ b/train_redpajama.py
@@ -76,7 +76,7 @@ def main(
     if fabric.global_rank == 0:
         os.makedirs(out_dir, exist_ok=True)
 
-    config = LLaMAConfig.from_name("7B")
+    config = LLaMAConfig(n_layer=12, n_head=4, n_embd=512)
 
     with fabric.device:
         torch.set_default_tensor_type(torch.HalfTensor)
@@ -267,9 +267,8 @@ def create_dataloaders(
 def get_batch(
     fabric: L.Fabric, data: np.ndarray, block_size: int
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    x = data[:, 0:block_size]
-    y = data[:, 1 : block_size + 1]
-    x, y = fabric.to_device((x.pin_memory(), y.pin_memory()))
+    x = data[:, 0 : block_size].contiguous()
+    y = data[:, 1 : block_size + 1].contiguous()
     return x, y
 
 

--- a/train_redpajama.py
+++ b/train_redpajama.py
@@ -96,6 +96,7 @@ def main(
         val_data_dir=val_data_dir,
         seed=1338,
     )
+    train_dataloader, val_dataloader = fabric.setup_dataloaders(train_dataloader, val_dataloader)
 
     optimizer = torch.optim.AdamW(
         model.parameters(),

--- a/train_redpajama.py
+++ b/train_redpajama.py
@@ -231,7 +231,7 @@ def create_dataloader(
 
     combined_dataset = CombinedDataset(datasets=datasets, seed=seed, weights=weights)
 
-    return DataLoader(combined_dataset, batch_size=batch_size, shuffle=False)
+    return DataLoader(combined_dataset, batch_size=batch_size, shuffle=False, pin_memory=True)
 
 
 def create_dataloaders(

--- a/train_redpajama.py
+++ b/train_redpajama.py
@@ -76,7 +76,7 @@ def main(
     if fabric.global_rank == 0:
         os.makedirs(out_dir, exist_ok=True)
 
-    config = LLaMAConfig(n_layer=12, n_head=4, n_embd=512)
+    config = LLaMAConfig.from_name("7B")
 
     with fabric.device:
         torch.set_default_tensor_type(torch.HalfTensor)


### PR DESCRIPTION
`Fabric.setup_dataloaders()` takes care of attaching a distributed sampler, which was missing here. Doing so will also move the data automatically to the device so we can delete the manual `fabric.to_device()`