### PR TITLE
Implement data-sharding in PackedDataset

### DIFF
--- a/lit_llama/packed_dataset.py
+++ b/lit_llama/packed_dataset.py
@@ -52,14 +52,9 @@ class PackedDataset(IterableDataset):
         shard_id = self._process_rank * num_workers + worker_id
         
         print(num_shards, shard_id, len(self._filenames))
-        
         filenames = self._filenames[shard_id::num_shards]
-        # filenames=[
-        #     el
-        #     for idx, el in enumerate(self._filenames)
-        #     if idx % num_shards == shard_id
-        # ]
         print(shard_id, filenames, len(filenames))
+        
         return PackedDatasetIterator(
             filenames=filenames,
             n_chunks=self._n_chunks,

--- a/lit_llama/packed_dataset.py
+++ b/lit_llama/packed_dataset.py
@@ -50,11 +50,8 @@ class PackedDataset(IterableDataset):
         worker_id = worker_info.id if worker_info is not None else 0
         num_shards = num_workers * self._num_processes
         shard_id = self._process_rank * num_workers + worker_id
-        
-        print(num_shards, shard_id, len(self._filenames))
         filenames = self._filenames[shard_id::num_shards]
-        print(shard_id, filenames, len(filenames))
-        
+
         return PackedDatasetIterator(
             filenames=filenames,
             n_chunks=self._n_chunks,

--- a/lit_llama/packed_dataset.py
+++ b/lit_llama/packed_dataset.py
@@ -50,7 +50,9 @@ class PackedDataset(IterableDataset):
         worker_id = worker_info.id if worker_info is not None else 0
         num_shards = num_workers * self._num_processes
         shard_id = self._process_rank * num_workers + worker_id
-        filenames = self._filenames[shard_id::num_shards]
+
+        max_num_files = len(self._filenames) // num_shards * num_shards
+        filenames = self._filenames[shard_id : max_num_files : num_shards]
 
         return PackedDatasetIterator(
             filenames=filenames,

--- a/lit_llama/packed_dataset.py
+++ b/lit_llama/packed_dataset.py
@@ -61,11 +61,6 @@ class PackedDataset(IterableDataset):
         )
 
 
-# 1 ['data/red_pajama/arxiv_sample_0000000000.bin', 'data/red_pajama/arxiv_sample_0000000010.bin', 'data/red_pajama/arxiv_sample_0000000021.bin', 'data/red_pajama/arxiv_sample_0000000023.bin', 'data/red_pajama/arxiv_sample_0000000020.bin', 'data/red_pajama/arxiv_sample_0000000019.bin', 'data/red_pajama/arxiv_sample_0000000026.bin']
-# 3 ['data/red_pajama/arxiv_sample_0000000016.bin', 'data/red_pajama/arxiv_sample_0000000027.bin', 'data/red_pajama/arxiv_sample_0000000001.bin', 'data/red_pajama/arxiv_sample_0000000024.bin', 'data/red_pajama/arxiv_sample_0000000011.bin', 'data/red_pajama/arxiv_sample_0000000007.bin', 'data/red_pajama/arxiv_sample_0000000013.bin']
-# 2 ['data/red_pajama/arxiv_sample_0000000006.bin', 'data/red_pajama/arxiv_sample_0000000003.bin', 'data/red_pajama/arxiv_sample_0000000022.bin', 'data/red_pajama/arxiv_sample_0000000018.bin', 'data/red_pajama/arxiv_sample_0000000012.bin', 'data/red_pajama/arxiv_sample_0000000005.bin', 'data/red_pajama/arxiv_sample_0000000025.bin']
-# 0 ['data/red_pajama/arxiv_sample_0000000002.bin', 'data/red_pajama/arxiv_sample_0000000028.bin', 'data/red_pajama/arxiv_sample_0000000014.bin', 'data/red_pajama/arxiv_sample_0000000004.bin', 'data/red_pajama/arxiv_sample_0000000017.bin', 'data/red_pajama/arxiv_sample_0000000009.bin', 'data/red_pajama/arxiv_sample_0000000008.bin']
-
 class PackedDatasetBuilder(object):
     def __init__(
         self,

--- a/tests/test_packed_dataset.py
+++ b/tests/test_packed_dataset.py
@@ -1,5 +1,5 @@
-import pytest
 import os
+from unittest.mock import MagicMock
 import requests
 
 from torch.utils.data import IterableDataset
@@ -161,3 +161,38 @@ def test_combined_dataset(tmp_path):
     assert 9 in res or 19 in res
     if len(res) > 10:
         assert 0 in res and 10 in res
+
+
+def test_sharded_packed_dataset(monkeypatch):
+    import lit_llama.packed_dataset
+    from lit_llama.packed_dataset import PackedDataset
+
+    dataset_iterator_mock = MagicMock()
+    monkeypatch.setattr(lit_llama.packed_dataset, "PackedDatasetIterator", dataset_iterator_mock)
+
+    # world_size = 1, rank = 0
+    filenames = [str(i) for i in range(10)]
+    iter(PackedDataset(filenames=filenames, n_chunks=2, block_size=2))
+    assert dataset_iterator_mock.call_args[1]["filenames"] == filenames
+    dataset_iterator_mock.reset_mock()
+    # world_size = 2, rank = 0
+    iter(PackedDataset(filenames=filenames, n_chunks=2, block_size=2, num_processes=2, process_rank=0))
+    assert dataset_iterator_mock.call_args[1]["filenames"] == ["0", "2", "4", "6", "8"]
+    dataset_iterator_mock.reset_mock()
+    # world_size = 2, rank = 1
+    iter(PackedDataset(filenames=filenames, n_chunks=2, block_size=2, num_processes=2, process_rank=1))
+    assert dataset_iterator_mock.call_args[1]["filenames"] == ["1", "3", "5", "7", "9"]
+    dataset_iterator_mock.reset_mock()
+    
+    # world_size = 3, rank = 0 (dataset size not cleanly divisible by world size)
+    iter(PackedDataset(filenames=filenames, n_chunks=2, block_size=2, num_processes=3, process_rank=0))
+    assert dataset_iterator_mock.call_args[1]["filenames"] == ["0", "3", "6"]
+    dataset_iterator_mock.reset_mock()
+    # world_size = 3, rank = 1 (dataset size not cleanly divisible by world size)
+    iter(PackedDataset(filenames=filenames, n_chunks=2, block_size=2, num_processes=3, process_rank=1))
+    assert dataset_iterator_mock.call_args[1]["filenames"] == ["1", "4", "7"]
+    dataset_iterator_mock.reset_mock()
+    # world_size = 3, rank = 2 (dataset size not cleanly divisible by world size)
+    iter(PackedDataset(filenames=filenames, n_chunks=2, block_size=2, num_processes=3, process_rank=2))
+    assert dataset_iterator_mock.call_args[1]["filenames"] == ["2", "5", "8"]
+    dataset_iterator_mock.reset_mock()

--- a/tests/test_packed_dataset.py
+++ b/tests/test_packed_dataset.py
@@ -169,9 +169,9 @@ def test_sharded_packed_dataset(monkeypatch):
 
     dataset_iterator_mock = MagicMock()
     monkeypatch.setattr(lit_llama.packed_dataset, "PackedDatasetIterator", dataset_iterator_mock)
+    filenames = [str(i) for i in range(10)]
 
     # world_size = 1, rank = 0
-    filenames = [str(i) for i in range(10)]
     iter(PackedDataset(filenames=filenames, n_chunks=2, block_size=2))
     assert dataset_iterator_mock.call_args[1]["filenames"] == filenames
     dataset_iterator_mock.reset_mock()
@@ -195,4 +195,3 @@ def test_sharded_packed_dataset(monkeypatch):
     # world_size = 3, rank = 2 (dataset size not cleanly divisible by world size)
     iter(PackedDataset(filenames=filenames, n_chunks=2, block_size=2, num_processes=3, process_rank=2))
     assert dataset_iterator_mock.call_args[1]["filenames"] == ["2", "5", "8"]
-    dataset_iterator_mock.reset_mock()

--- a/train_redpajama.py
+++ b/train_redpajama.py
@@ -78,17 +78,6 @@ def main(
 
     config = LLaMAConfig.from_name("7B")
 
-    with fabric.device:
-        torch.set_default_tensor_type(torch.HalfTensor)
-        model = LLaMA(config).bfloat16()
-        model.apply(model._init_weights)
-        torch.set_default_tensor_type(torch.FloatTensor)
-
-    # if compile:
-    #     model = torch.compile(model)
-
-    model = fabric.setup_module(model)
-
     train_dataloader, val_dataloader = create_dataloaders(
         batch_size=micro_batch_size,
         block_size=config.block_size,
@@ -98,18 +87,28 @@ def main(
     )
     train_dataloader, val_dataloader = fabric.setup_dataloaders(train_dataloader, val_dataloader)
 
+    with fabric.device:
+        torch.set_default_tensor_type(torch.HalfTensor)
+        model = LLaMA(config).bfloat16()
+        model.apply(model._init_weights)
+        torch.set_default_tensor_type(torch.FloatTensor)
+
+    # if compile:
+    #     model = torch.compile(model)
+
     optimizer = torch.optim.AdamW(
         model.parameters(),
         lr=learning_rate,
         weight_decay=weight_decay,
         betas=(beta1, beta2),
     )
-    optimizer = fabric.setup_optimizers(optimizer)
+
+    model, optimizer = fabric.setup(model, optimizer)
 
     process_batch_size = batch_size // devices
     grad_accum_steps = process_batch_size // micro_batch_size
 
-    train(fabric, model, optimizer, train_dataloader, val_dataloader, grad_accum_steps)
+    train(fabric, model, optimizer, train_dataloader, val_dataloader, grad_accum_steps, devices)
 
 
 def train(
@@ -119,6 +118,7 @@ def train(
     train_dataloader: DataLoader,
     val_dataloader: Optional[DataLoader],
     grad_accum_steps: int,
+    devices: int,
 ) -> None:
     """The training loop.
 
@@ -127,18 +127,24 @@ def train(
 
     step_count = 0
 
+    step_time = 0.0
+    tokens = 0
+    tokens_sec = 0.0
+    prev_t1 = time.time()
+
     for iter_num, train_data in enumerate(train_dataloader):
+        t0 = time.time()
+
         # determine and set the learning rate for this iteration
         lr = get_lr(iter_num) if decay_lr else learning_rate
         for param_group in optimizer.param_groups:
             param_group["lr"] = lr
 
-        t0 = time.time()
 
         input_ids = train_data[:, 0 : model.config.block_size].contiguous()
         targets = train_data[:, 1 : model.config.block_size + 1].contiguous()
         
-        is_accumulating = (iter_num + 1) % grad_accum_steps == 0
+        is_accumulating = (iter_num + 1) % grad_accum_steps != 0
 
         with fabric.no_backward_sync(model, enabled=is_accumulating):
             logits = model(input_ids)
@@ -147,12 +153,16 @@ def train(
             )
             fabric.backward(loss / grad_accum_steps)
 
+        t1 = time.time()
+
         if not is_accumulating:
             fabric.clip_gradients(model, optimizer, max_norm=grad_clip)
 
             optimizer.step()
             optimizer.zero_grad()
             step_count += 1
+
+            t1 = time.time()
 
             if step_count % eval_interval == 0:
                 val_loss = validate(fabric, model, val_dataloader)
@@ -168,14 +178,25 @@ def train(
                     fabric, model, os.path.join(out_dir, f"iter-{iter_num:06d}-ckpt.pth")
                 )
 
-        dt = time.time() - t0
+        dt = t1 - t0
+
+        tokens += micro_batch_size * model.config.block_size
+        step_time += t1 - prev_t1
+        prev_t1 = t1
+
         if iter_num % log_interval == 0:
+            tokens_sec_str = f"{tokens / step_time:.0f}" if not is_accumulating else "-"
+
             fabric.log_dict(
                 {"iter": iter_num, "train_loss": loss, "step": step_count, "lr": lr}
             )
             fabric.print(
-                f"iter {iter_num}: loss {loss.item():.4f}, time: {dt*1000:.2f}ms"
+                    f"iter {iter_num}: loss {loss.item():.4f}, time: {dt*1000:.2f}ms, speed: {tokens_sec_str} toks/s/device"
             )
+
+        if not is_accumulating:
+            tokens = 0
+            step_time = 0.0
 
         if iter_num > max_iters:
             break

--- a/train_redpajama.py
+++ b/train_redpajama.py
@@ -235,7 +235,7 @@ def create_dataloader(
     for prefix, _ in data_config:
         filenames = glob.glob(os.path.join(data_dir, prefix + "*"))
         dataset = PackedDataset(
-            filenames, n_chunks=10, block_size=block_size, shuffle=shuffle, seed=seed,
+            filenames, n_chunks=4, block_size=block_size, shuffle=shuffle, seed=seed,
             num_processes=fabric.world_size, process_rank=fabric.global_rank,
         )
         datasets.append(dataset)


### PR DESCRIPTION
Follow-up to #217

The iterable dataset implementation for redpajama so far supported only sharding the data across the dataloader workers, but not globally across all processes in a distributed setting, e.g., Fabric(devices > 1).