### PR TITLE
Fix Gradient Accumulation Logic

### DIFF
--- a/finetune_full.py
+++ b/finetune_full.py
@@ -97,7 +97,7 @@ def train(
 
     for iter_num in range(max_iters):
 
-        is_accumulating = (iter_num + 1) % gradient_accumulation_steps == 0
+        is_accumulating = (iter_num + 1) % gradient_accumulation_steps != 0
 
         if step_count <= warmup_steps:
             # linear warmup


### PR DESCRIPTION
This fixes the gradient accumulation logic in finetune_full.py.

Since weight update should occur once in every {gradient_accumulation_steps} iterations, I think "==" in line 100 should be "!=".

I would appreciate any comments about this :) 