### PR TITLE
Set default paths in the signatures

### DIFF
--- a/evaluate.py
+++ b/evaluate.py
@@ -45,8 +45,8 @@ def main(
     # compilation fails as it does not support torch.complex64 for RoPE
     # compile: bool = False,
     accelerator: str = "auto",
-    checkpoint_path: Optional[Path] = None,
-    tokenizer_path: Optional[Path] = None,
+    checkpoint_path: Path = Path("checkpoints/lit-llama/7B/lit-llama.pth"),
+    tokenizer_path: Path = Path("checkpoints/lit-llama/tokenizer.model"),
     dtype: str = "float32",
     quantize: Optional[str] = None,
 ) -> None:
@@ -63,10 +63,6 @@ def main(
             ``"llm.int8"``: LLM.int8() mode,
             ``"gptq.int4"``: GPTQ 4-bit mode.
     """
-    if not checkpoint_path:
-        checkpoint_path = Path(f"./checkpoints/lit-llama/7B/lit-llama.pth")
-    if not tokenizer_path:
-        tokenizer_path = Path("./checkpoints/lit-llama/tokenizer.model")
     assert checkpoint_path.is_file()
     assert tokenizer_path.is_file()
 

--- a/evaluate_adapter.py
+++ b/evaluate_adapter.py
@@ -47,9 +47,9 @@ def main(
     # compilation fails as it does not support torch.complex64 for RoPE
     # compile: bool = False,
     accelerator: str = "auto",
-    adapter_path: Optional[Path] = None,
-    checkpoint_path: Optional[Path] = None,
-    tokenizer_path: Optional[Path] = None,
+    adapter_path: Path = Path("out/adapter/alpaca/lit-llama-adapter-finetuned.pth"),
+    checkpoint_path: Path = Path("checkpoints/lit-llama/7B/lit-llama.pth"),
+    tokenizer_path: Path = Path("checkpoints/lit-llama/tokenizer.model"),
     dtype: str = "float32",
     quantize: Optional[str] = None,
 ) -> None:
@@ -68,13 +68,6 @@ def main(
             ``"llm.int8"``: LLM.int8() mode,
             ``"gptq.int4"``: GPTQ 4-bit mode.
     """
-    if not adapter_path:
-        adapter_path = Path("out/adapter/alpaca/lit-llama-adapter-finetuned.pth")
-    if not checkpoint_path:
-        checkpoint_path = Path(f"./checkpoints/lit-llama/7B/lit-llama.pth")
-    if not tokenizer_path:
-        tokenizer_path = Path("./checkpoints/lit-llama/tokenizer.model")
-    
     assert adapter_path.is_file()
     assert checkpoint_path.is_file()
     assert tokenizer_path.is_file()

--- a/evaluate_full.py
+++ b/evaluate_full.py
@@ -46,7 +46,7 @@ def main(
     # compile: bool = False,
     accelerator: str = "auto",
     checkpoint_path: Optional[Path] = None,
-    tokenizer_path: Optional[Path] = None,
+    tokenizer_path: Path = Path("checkpoints/lit-llama/tokenizer.model"),
     model_size: str = "7B",
     dtype: str = "float32",
     quantize: Optional[str] = None,
@@ -65,9 +65,7 @@ def main(
             ``"gptq.int4"``: GPTQ 4-bit mode.
     """
     if not checkpoint_path:
-        checkpoint_path = Path(f"./checkpoints/lit-llama/{model_size}/lit-llama.pth")
-    if not tokenizer_path:
-        tokenizer_path = Path("./checkpoints/lit-llama/tokenizer.model")
+        checkpoint_path = Path(f"checkpoints/lit-llama/{model_size}/lit-llama.pth")
     assert checkpoint_path.is_file()
     assert tokenizer_path.is_file()
 

--- a/evaluate_lora.py
+++ b/evaluate_lora.py
@@ -51,9 +51,9 @@ def main(
     # compilation fails as it does not support torch.complex64 for RoPE
     # compile: bool = False,
     accelerator: str = "auto",
-    lora_path: Optional[Path] = None,
-    checkpoint_path: Optional[Path] = None,
-    tokenizer_path: Optional[Path] = None,
+    lora_path: Path = Path("out/lora/alpaca/lit-llama-lora-finetuned.pth"),
+    checkpoint_path: Path = Path("checkpoints/lit-llama/7B/lit-llama.pth"),
+    tokenizer_path: Path = Path("checkpoints/lit-llama/tokenizer.model"),
     dtype: str = "float32",
     quantize: Optional[str] = None,
 ) -> None:
@@ -73,12 +73,6 @@ def main(
             ``"llm.int8"``: LLM.int8() mode,
             ``"gptq.int4"``: GPTQ 4-bit mode.
     """
-    if not lora_path:
-        lora_path = Path("out/lora/alpaca/lit-llama-lora-finetuned.pth")
-    if not checkpoint_path:
-        checkpoint_path = Path(f"./checkpoints/lit-llama/7B/lit-llama.pth")
-    if not tokenizer_path:
-        tokenizer_path = Path("./checkpoints/lit-llama/tokenizer.model")
     assert lora_path.is_file()
     assert checkpoint_path.is_file()
     assert tokenizer_path.is_file()

--- a/generate.py
+++ b/generate.py
@@ -77,8 +77,8 @@ def main(
     max_new_tokens: int = 50,
     top_k: int = 200,
     temperature: float = 0.8,
-    checkpoint_path: Optional[Path] = None,
-    tokenizer_path: Optional[Path] = None,
+    checkpoint_path: Path = Path("checkpoints/lit-llama/7B/lit-llama.pth"),
+    tokenizer_path: Path = Path("checkpoints/lit-llama/tokenizer.model"),
     quantize: Optional[str] = None,
 ) -> None:
     """Generates text samples based on a pre-trained LLaMA model and tokenizer.
@@ -96,10 +96,6 @@ def main(
             ``"llm.int8"``: LLM.int8() mode,
             ``"gptq.int4"``: GPTQ 4-bit mode.
     """
-    if not checkpoint_path:
-        checkpoint_path = Path(f"./checkpoints/lit-llama/7B/lit-llama.pth")
-    if not tokenizer_path:
-        tokenizer_path = Path("./checkpoints/lit-llama/tokenizer.model")
     assert checkpoint_path.is_file(), checkpoint_path
     assert tokenizer_path.is_file(), tokenizer_path
 

--- a/generate_adapter.py
+++ b/generate_adapter.py
@@ -17,9 +17,9 @@ from scripts.prepare_alpaca import generate_prompt
 def main(
     prompt: str = "What food do lamas eat?",
     input: str = "",
-    adapter_path: Optional[Path] = None,
-    pretrained_path: Optional[Path] = None,
-    tokenizer_path: Optional[Path] = None,
+    adapter_path: Path = Path("out/adapter/alpaca/lit-llama-adapter-finetuned.pth"),
+    pretrained_path: Path = Path("checkpoints/lit-llama/7B/lit-llama.pth"),
+    tokenizer_path: Path = Path("checkpoints/lit-llama/tokenizer.model"),
     quantize: Optional[str] = None,
     max_new_tokens: int = 100,
     top_k: int = 200,
@@ -44,13 +44,6 @@ def main(
         temperature: A value controlling the randomness of the sampling process. Higher values result in more random
             samples.
     """
-    if not adapter_path:
-        adapter_path = Path("out/adapter/alpaca/lit-llama-adapter-finetuned.pth")
-    if not pretrained_path:
-        pretrained_path = Path(f"./checkpoints/lit-llama/7B/lit-llama.pth")
-    if not tokenizer_path:
-        tokenizer_path = Path("./checkpoints/lit-llama/tokenizer.model")
-    
     assert adapter_path.is_file()
     assert pretrained_path.is_file()
     assert tokenizer_path.is_file()

--- a/generate_full.py
+++ b/generate_full.py
@@ -78,7 +78,7 @@ def main(
     top_k: int = 200,
     temperature: float = 0.8,
     checkpoint_path: Optional[Path] = None,
-    tokenizer_path: Optional[Path] = None,
+    tokenizer_path: Path = Path("checkpoints/lit-llama/tokenizer.model"),
     model_size: str = "7B",
     quantize: Optional[str] = None,
 ) -> None:
@@ -99,9 +99,7 @@ def main(
             ``"gptq.int4"``: GPTQ 4-bit mode.
     """
     if not checkpoint_path:
-        checkpoint_path = Path(f"./checkpoints/lit-llama/{model_size}/lit-llama.pth")
-    if not tokenizer_path:
-        tokenizer_path = Path("./checkpoints/lit-llama/tokenizer.model")
+        checkpoint_path = Path(f"checkpoints/lit-llama/{model_size}/lit-llama.pth")
     assert checkpoint_path.is_file(), checkpoint_path
     assert tokenizer_path.is_file(), tokenizer_path
 

--- a/generate_lora.py
+++ b/generate_lora.py
@@ -21,9 +21,9 @@ lora_dropout = 0.05
 def main(
     prompt: str = "What food do lamas eat?",
     input: str = "",
-    lora_path: Optional[Path] = None,
-    pretrained_path: Optional[Path] = None,
-    tokenizer_path: Optional[Path] = None,
+    lora_path: Path = Path("out/lora/alpaca/lit-llama-lora-finetuned.pth"),
+    pretrained_path: Path = Path("checkpoints/lit-llama/7B/lit-llama.pth"),
+    tokenizer_path: Path = Path("checkpoints/lit-llama/tokenizer.model"),
     quantize: Optional[str] = None,
     dtype: str = "float32",
     max_new_tokens: int = 100,
@@ -50,13 +50,6 @@ def main(
         temperature: A value controlling the randomness of the sampling process. Higher values result in more random
             samples.
     """
-    if not lora_path:
-        lora_path = Path("out/lora/alpaca/lit-llama-lora-finetuned.pth")
-    if not pretrained_path:
-        pretrained_path = Path(f"./checkpoints/lit-llama/7B/lit-llama.pth")
-    if not tokenizer_path:
-        tokenizer_path = Path("./checkpoints/lit-llama/tokenizer.model")
-    
     assert lora_path.is_file()
     assert pretrained_path.is_file()
     assert tokenizer_path.is_file()

--- a/quantize.py
+++ b/quantize.py
@@ -136,9 +136,9 @@ def llama_blockwise_quantization(
 
 def main(
     *,
-    checkpoint_path: Optional[Path] = None,
+    checkpoint_path: Path = Path("checkpoints/lit-llama/7B/lit-llama.pth"),
     output_path: Optional[Path] = None,
-    tokenizer_path: Optional[Path] = None,
+    tokenizer_path: Path = Path("checkpoints/lit-llama/tokenizer.model"),
     n_samples: int = 128,
     dtype: str = "float32",
     quantize: Optional[str] = None,
@@ -156,10 +156,6 @@ def main(
             ``"gptq.int4"``: GPTQ 4-bit mode.
             Note that ``"llm.int8"```does not need a quantization step.
     """
-    if not checkpoint_path:
-        checkpoint_path = Path(f"./checkpoints/lit-llama/7B/lit-llama.pth")
-    if not tokenizer_path:
-        tokenizer_path = Path("./checkpoints/lit-llama/tokenizer.model")
     assert checkpoint_path.is_file()
     assert tokenizer_path.is_file()
     assert output_path.parent.is_dir() and (


### PR DESCRIPTION
Minor simplifcation.

Having them as None is an artifact from the time where we were formatting the path with the `---model_size`