### PR TITLE
Fix path string to prevent the error: TypeError

### DIFF
--- a/scripts/prepare_alpaca.py
+++ b/scripts/prepare_alpaca.py
@@ -35,7 +35,7 @@ def prepare(
     """
     
     destination_path.mkdir(parents=True, exist_ok=True)
-    file_path = destination_path / data_file_name
+    file_path = f"{destination_path}/{data_file_name}"
     download(file_path)
 
     # TODO: If we don't have the Meta weights, where do we get the tokenizer from?
@@ -58,11 +58,11 @@ def prepare(
 
     print("Processing train split ...")
     train_set = [prepare_sample(sample, tokenizer, max_seq_length, mask_inputs) for sample in tqdm(train_set)]
-    torch.save(train_set, file_path.parent / "train.pt")
+    torch.save(train_set, f"{file_path.parent}/train.pt")
 
     print("Processing test split ...")
     test_set = [prepare_sample(sample, tokenizer, max_seq_length, mask_inputs) for sample in tqdm(test_set)]
-    torch.save(test_set, file_path.parent / "test.pt")
+    torch.save(test_set, f"{file_path.parent}/test.pt")
 
 
 def download(file_path: Path):

--- a/scripts/prepare_dolly.py
+++ b/scripts/prepare_dolly.py
@@ -34,7 +34,7 @@ def prepare(
     """
     
     destination_path.mkdir(parents=True, exist_ok=True)
-    file_path = destination_path / DATA_FILE_NAME
+    file_path = f"{destination_path}/{DATA_FILE_NAME}"
     download(file_path)
 
     # TODO: If we don't have the Meta weights, where do we get the tokenizer from?
@@ -61,11 +61,11 @@ def prepare(
 
     print("Processing train split ...")
     train_set = [prepare_sample(sample, tokenizer, max_seq_length, mask_inputs) for sample in tqdm(train_set)]
-    torch.save(train_set, file_path.parent / "train.pt")
+    torch.save(train_set, f"{file_path.parent}/train.pt")
 
     print("Processing test split ...")
     test_set = [prepare_sample(sample, tokenizer, max_seq_length, mask_inputs) for sample in tqdm(test_set)]
-    torch.save(test_set, file_path.parent / "test.pt")
+    torch.save(test_set, f"{file_path.parent}/test.pt")
 
 
 def download(file_path: Path):

--- a/scripts/prepare_redpajama.py
+++ b/scripts/prepare_redpajama.py
@@ -56,7 +56,7 @@ def prepare_sample(
         if match and match not in name:
             continue
 
-        filepath = source_path / name
+        filepath = f"{source_path}/{name}"
 
         if not filepath.is_file():
             raise RuntimeError(
@@ -128,7 +128,7 @@ def prepare_full(
         )
 
         for name in filenames:
-            filepath = source_path / name
+            filepath = f"{source_path}/{name}"
 
             print(f"Processing {name}")
 

--- a/scripts/prepare_shakespeare.py
+++ b/scripts/prepare_shakespeare.py
@@ -35,7 +35,7 @@ def prepare(destination_path: Path = Path("data/shakespeare")) -> None:
     destination_path.mkdir(parents=True, exist_ok=True)
 
     # download the tiny shakespeare dataset
-    input_file_path = destination_path / "input.txt"
+    input_file_path = f"{destination_path}/input.txt"
     if not input_file_path.exists():
         data_url = "https://raw.githubusercontent.com/karpathy/char-rnn/master/data/tinyshakespeare/input.txt"
         with open(input_file_path, "w") as f:
@@ -59,8 +59,8 @@ def prepare(destination_path: Path = Path("data/shakespeare")) -> None:
     # export to bin files
     train_ids = np.array(train_ids, dtype=np.uint16)
     val_ids = np.array(val_ids, dtype=np.uint16)
-    train_ids.tofile(destination_path / "train.bin")
-    val_ids.tofile(destination_path / "val.bin")
+    train_ids.tofile(f"{destination_path}/train.bin")
+    val_ids.tofile(f"{destination_path}/val.bin")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The original syntax results in the following error in python 3.9

train_ids.tofile(destination_path / "train.bin")
TypeError: unsupported operand type(s) for /: 'str' and 'str'