### PR TITLE
refine llama model lookup for the benefit of quantized weights

### DIFF
--- a/lit_llama/utils.py
+++ b/lit_llama/utils.py
@@ -27,7 +27,7 @@ def llama_model_lookup(checkpoint: dict) -> str:
     
     Checks the width of the lm_head.weight matrix, as these uniquely identify the model.
     """
-    embedding_size = checkpoint["lm_head.weight"].shape[1]
+    embedding_size = checkpoint['transformer.wte.weight'].shape[1]
     return llama_model_sizes[embedding_size]
 
 


### PR DESCRIPTION
Fixes: #258 
Of course, this works while we don't do funny stuff to the embedding layer.
I'm not entirely sure how to test with weights...