### PR TITLE
Update generate function to include generate_prompt call

### DIFF
--- a/generate/full.py
+++ b/generate/full.py
@@ -9,7 +9,7 @@ import torch
 
 from lit_llama import LLaMA, Tokenizer
 from lit_llama.utils import EmptyInitOnDevice
-
+from scripts.prepare_alpaca import generate_prompt
 
 @torch.no_grad()
 def generate(
@@ -121,6 +121,8 @@ def main(
     model = fabric.setup_module(model)
 
     tokenizer = Tokenizer(tokenizer_path)
+    sample = {"instruction": prompt, "input": input}
+    prompt = generate_prompt(sample)
     encoded = tokenizer.encode(prompt, bos=True, eos=False, device=fabric.device)
     prompt_length = encoded.size(0)
 


### PR DESCRIPTION
This pull request addresses the issue discussed in the comments regarding the 'generate/full.py' file. The changes include calling the `generate_prompt` function before the `generate` function, as it seems to produce a correct response.

Changes made:
1. Added a call to `generate_prompt` before the `generate` function in the 'generate/full.py' file.
2. Updated the encoding step to include the newly generated prompt.

These changes should improve the correctness of the response generation process. Please review and let me know if any further changes are required.


Fixes  #246