### PR TITLE
Clarify how to use int4 quantization

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,14 @@ You can also use GPTQ-style int4 quantization, but this needs conversions of the
 python quantize/gptq.py --checkpoint_path lit-llama.pth --tokenizer_path tokenizer.model --output_path llama-7b-gptq.4bit.pth --dtype bfloat16  --quantize gptq.int4
 ```
 
-With the generated quantized checkpoint generation works as usual with `--quantize gptq.int4`, bringing GPU usage to about ~5GB. As only the weights of the Linear layers are quantized, it is useful to use `--dtype bfloat16` even with the quantization enabled.
+GPTQ-style int4 quantization brings GPU usage down to about ~5GB. As only the weights of the Linear layers are quantized, it is useful to also use `--dtype bfloat16` even with the quantization enabled.
+
+With the generated quantized checkpoint generation quantization then works as usual with `--quantize gptq.int4` and the newly generated checkpoint file:
+
+
+```bash
+python generate.py --quantize gptq.int4 --checkpoint_path checkpoints/lit-llama/7B/llama-7b-gptq.4bit.pth
+```
 
 [Full guide for generating samples from the model](howto/inference.md).
 

--- a/howto/inference.md
+++ b/howto/inference.md
@@ -34,4 +34,11 @@ You can also use GPTQ-style int4 quantization, but this needs conversions of the
 python quantize/gptq.py --checkpoint_path lit-llama.pth --tokenizer_path tokenizer.model --output_path llama-7b-gptq.4bit.pt --dtype bfloat16  --quantize gptq.int4
 ```
 
-With the generated quantized checkpoint generation works as usual with `--quantize gptq.int4`, bringing GPU usage to about ~5GB. As only the weights of the Linear layers are quantized, it is useful to use `--dtype bfloat16` even with the quantization enabled.
+GPTQ-style int4 quantization brings GPU usage down to about ~5GB. As only the weights of the Linear layers are quantized, it is useful to also use `--dtype bfloat16` even with the quantization enabled.
+
+With the generated quantized checkpoint generation quantization then works as usual with `--quantize gptq.int4` and the newly generated checkpoint file:
+
+
+```bash
+python generate.py --quantize gptq.int4 --checkpoint_path checkpoints/lit-llama/7B/llama-7b-gptq.4bit.pth
+```


### PR DESCRIPTION
It was not quite clear how to use the int4 quantized checkpoints after the conversion (and whether to use the dtype bfloat16 for this, which was referenced in the text). I added an example to clarify this.