### PR TITLE
Multihead gating for adapter

### DIFF
--- a/lit_llama/adapter.py
+++ b/lit_llama/adapter.py
@@ -37,7 +37,7 @@ class CausalSelfAttention(nn.Module):
             # adapter embedding layer
             self.adapter_wte = nn.Embedding(config.adapter_prompt_length, config.n_embd)
             # gate for adaption
-            self.gating_factor = torch.nn.Parameter(torch.zeros(1))
+            self.gating_factor = torch.nn.Parameter(torch.zeros(1, config.n_head, 1, 1))
 
         self.n_head = config.n_head
         self.n_embd = config.n_embd

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -1,6 +1,7 @@
 from dataclasses import asdict
 import pytest
 import sys
+import torch
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="EmptyInitOnDevice on CPU not working for Windows.")
@@ -21,3 +22,24 @@ def test_config_identical(model_size, lit_llama):
         llama_model = llama.LLaMA.from_name(model_size)
         adapter_model = llama_adapter.LLaMA.from_name(model_size)
         assert llama_model.lm_head.weight.shape == adapter_model.lm_head.weight.shape
+
+
+def test_adapter_load_gating_factor():
+    """Tests backward-compatible loading of checkpoints after the `gating_factor` was extended per-head
+    in PR #297.
+    """
+    import lit_llama.adapter as llama_adapter
+    from lit_llama.utils import lazy_load
+
+    config = llama_adapter.LLaMAConfig(n_head=4, block_size=100, n_embd=16)
+    attn = llama_adapter.CausalSelfAttention(config=config, block_idx=3)
+
+    state_dict={
+        "gating_factor": torch.tensor(0.42),  # in old checkpoints, this was a scalar
+        "c_attn.weight": torch.zeros(3 * 16, 16),
+        "c_proj.weight": torch.zeros(16, 16),
+        "adapter_wte.weight": torch.zeros(10, 16),
+    }
+
+    attn.load_state_dict(state_dict=state_dict)
+    assert torch.equal(attn.gating_factor, torch.full((1, 4, 1, 1), 0.42))

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -24,7 +24,7 @@ def test_config_identical(model_size, lit_llama):
         assert llama_model.lm_head.weight.shape == adapter_model.lm_head.weight.shape
 
 
-def test_adapter_load_gating_factor():
+def test_adapter_load_gating_factor(lit_llama):
     """Tests backward-compatible loading of checkpoints after the `gating_factor` was extended per-head
     in PR #297.
     """


### PR DESCRIPTION
As discussed in #296 , the gating should probably be individual for each of the attention heads as described in the paper, and as in the code implementation in the original LLaMA-Adapter repo.

I just gave it a try and don't notice any performance differences (getting similar loss convergence), so it probably doesn't make a big difference in practice. But I guess making it more similar to the paper is not a bad idea.

Fixes #296