### PR TITLE
protecting from a weird inconsistency on tensor indexing operations

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -73,7 +73,7 @@ def generate(
             xm.mark_step()
 
         # concatenate the new generation
-        idx[t] = idx_next
+        idx[t] = idx_next.item()
 
         # if <eos> token is triggered, return the output (stop generation)
         if idx_next == eos_id:


### PR DESCRIPTION
There is a weird inconsistency on tensor indexing operations, maybe depending on different python/pytorch combinations. See the example below where I regenerated the issue. The change on this PR will make it more stable.

>  Testing environment
>   - Python 3.8.16
>   - Pytorch 2.0.1
> 
>  Machine info
>   - Apple M1 Max
>   - OSX 13.4 (22F66)


```
>>> a = torch.tensor([31843, 16644, 31844,   629,  1382,   322,     0,     0,     0,     0,
            0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
            0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
            0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
            0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
            0,     0,     0,     0,     0,     0], device='mps:0',
       dtype=torch.int32)
>>> b = torch.tensor([1568], device='mps:0')
>>> a[10] = b # See the weird behavior below, it put 1568 into 0'th element instead of the 10th element.
>>> a = torch.tensor([1568, 16644, 31844,   629,  1382,   322,     0,     0,     0,     0,
            0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
            0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
            0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
            0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
            0,     0,     0,     0,     0,     0], device='mps:0',
       dtype=torch.int32)
>>> a[10] = b.item() # However, b.item() behaves normally as expected
>>> a = torch.tensor([1568, 16644, 31844,   629,  1382,   322,     0,     0,     0,     0,
         1568,     0,     0,     0,     0,     0,     0,     0,     0,     0,
            0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
            0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
            0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
            0,     0,     0,     0,     0,     0], device='mps:0',
       dtype=torch.int32)
```

