### PR TITLE
Do #298 only for MPS

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -73,7 +73,8 @@ def generate(
             xm.mark_step()
 
         # concatenate the new generation
-        idx[t] = idx_next.item()
+        # https://github.com/pytorch/pytorch/issues/101936
+        idx[t] = idx_next.item() if idx.device.type == "mps" else idx_next
 
         # if <eos> token is triggered, return the output (stop generation)
         if idx_next == eos_id:

--- a/generate/full.py
+++ b/generate/full.py
@@ -61,7 +61,8 @@ def generate(
         idx_next = torch.multinomial(probs, num_samples=1)
 
         # concatenate the new generation
-        idx[t] = idx_next
+        # https://github.com/pytorch/pytorch/issues/101936
+        idx[t] = idx_next.item() if idx.device.type == "mps" else idx_next
 
         # if <eos> token is triggered, return the output (stop generation)
         if idx_next == eos_id:


### PR DESCRIPTION
Fixes https://github.com/Lightning-AI/lit-llama/pull/298#discussion_r1199802188

From the linked pull, the issue seems to happen only on MPS. In that case, we shouldn't call `.item()` for other backends as it moves from device and back unnecesarily