### PR TITLE
[WIP] Fix quantization for adapter v2

### DIFF
--- a/lit_llama/adapter_v2.py
+++ b/lit_llama/adapter_v2.py
@@ -32,8 +32,14 @@ def adapter_v2_new_forward(self, input: Tensor) -> Tensor:
 
 
 def adapter_v2_linear_with_bias_and_scale(layer):
-    layer.adapter_bias = torch.nn.Parameter(torch.zeros(layer.weight.shape[0]), requires_grad=True)
-    layer.adapter_scale = torch.nn.Parameter(torch.ones(layer.weight.shape[0]), requires_grad=True)
+    layer.adapter_bias = torch.nn.Parameter(
+        torch.zeros(layer.weight.shape[0], dtype=layer.weight.dtype),
+        requires_grad=False,
+        )
+    layer.adapter_scale = torch.nn.Parameter(
+        torch.ones(layer.weight.shape[0], dtype=layer.weight.dtype),
+        requires_grad=False,
+        )
     bound_method = adapter_v2_new_forward.__get__(layer, layer.__class__)
     setattr(layer, 'forward', bound_method)
     return layer


### PR DESCRIPTION
Arg, I noticed that llm.int8() quantization breaks for adapter-v2-finetuned models, giving a

```python
    F.linear(input, self.weight, self.bias) + self.adapter_bias
RuntimeError: expected mat1 and mat2 to have the same dtype, but got: c10::BFloat16 != signed char
```

error. 

I tried manually setting the `dtype` in the new v2 parameters (see this PR) but still get the same issue. Is there perhaps something I should be doing with 

```python
    with fabric.device:
        torch.set_default_tensor_type(...)
```