### PR TITLE
Fix RMS_eps

### DIFF
--- a/lit_llama/model.py
+++ b/lit_llama/model.py
@@ -259,7 +259,7 @@ class RMSNorm(nn.Module):
     https://github.com/bzhangGo/rmsnorm/blob/master/LICENSE.
     """
 
-    def __init__(self, size: int, dim: int = -1, eps: float = 1e-5) -> None:
+    def __init__(self, size: int, dim: int = -1, eps: float = 1e-6) -> None:
         super().__init__()
         self.scale = nn.Parameter(torch.ones(size))
         self.eps = eps


### PR DESCRIPTION
This ensures that logits from lit-llama model are "the same" as logits of meta/llama repo. Also referencing https://discord.com/channels/1077906959069626439/1110860278792466512