### PR TITLE
add incremental_save to utils, use in convert_hf_checkpoint

### DIFF
--- a/lit_llama/utils.py
+++ b/lit_llama/utils.py
@@ -314,3 +314,160 @@ class lazy_load:
     def __exit__(self, exc_type, exc_val, exc_tb):
         del self.zf  # I don't think there is a way to force closing...
         self.zf = None
+
+
+class SavingProxyForStorage:
+    def __init__(self, obj, saver, protocol_version=5):
+        self.protocol_version = protocol_version
+        self.saver = saver
+        if not (isinstance(obj, torch.storage.TypedStorage) or torch.is_storage(obj)):
+            raise TypeError(f"expected storage, not {type(obj)}")
+
+        # this logic is taken from PyTorch 2.0+ torch/serialization.py
+        if isinstance(obj, torch.storage.TypedStorage):
+            # PT upstream wants to deprecate this eventually...
+            storage = obj._untyped_storage
+            storage_dtype = obj.dtype
+            storage_type_str = obj._pickle_storage_type()
+            storage_type = getattr(torch, storage_type_str)
+            storage_numel = obj._size()
+        else:
+            storage = obj
+            storage_dtype = torch.uint8
+            storage_type = normalize_storage_type(type(obj))
+            storage_numel = storage.nbytes()
+
+        storage_key = saver._write_storage_and_return_key(storage)
+        location = torch.serialization.location_tag(storage)
+
+        self.storage_info = (
+            "storage",
+            storage_type,
+            storage_key,
+            location,
+            storage_numel,
+        )
+
+    def __reduce_ex__(self, protocol_version):
+        raise RuntimeError("this should be handled with out of band")
+
+
+class SavingProxyForTensor:
+    def __init__(self, tensor, saver, protocol_version=5):
+        self.protocol_version = protocol_version
+        self.reduce_ret_fn, (storage, *other_reduce_args) = tensor.__reduce_ex__(
+            protocol_version
+        )
+        assert isinstance(
+            storage, torch.storage.TypedStorage
+        ), "Please check for updates"
+        storage_proxy = SavingProxyForStorage(
+            storage, saver, protocol_version=protocol_version
+        )
+        self.reduce_args = (storage_proxy, *other_reduce_args)
+
+    def __reduce_ex__(self, protocol_version):
+        if protocol_version != self.protocol_version:
+            raise RuntimeError(
+                f"Unexpected protocol version: expected {self.protocol_version}, got {protocol_version}"
+            )
+        return self.reduce_ret_fn, self.reduce_args
+
+
+class IncrementalPyTorchPickler(pickle.Pickler):
+    def __init__(self, saver, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.storage_dtypes = {}
+        self.saver = saver
+        self.id_map = {}
+
+    # this logic is taken from PyTorch 2.0+ torch/serialization.py
+    def persistent_id(self, obj):
+        # FIXME: the docs say that persistent_id should only return a string
+        # but torch store returns tuples. This works only in the binary protocol
+        # see
+        # https://docs.python.org/2/library/pickle.html#pickling-and-unpickling-external-objects
+        # https://github.com/python/cpython/blob/master/Lib/pickle.py#L527-L537
+        if isinstance(obj, SavingProxyForStorage):
+            return obj.storage_info
+
+        if isinstance(obj, torch.storage.TypedStorage) or torch.is_storage(obj):
+            if isinstance(obj, torch.storage.TypedStorage):
+                # TODO: Once we decide to break serialization FC, this case
+                # can be deleted
+                storage = obj._untyped_storage
+                storage_dtype = obj.dtype
+                storage_type_str = obj._pickle_storage_type()
+                storage_type = getattr(torch, storage_type_str)
+                storage_numel = obj._size()
+
+            else:
+                storage = obj
+                storage_dtype = torch.uint8
+                storage_type = normalize_storage_type(type(obj))
+                storage_numel = storage.nbytes()
+
+            # If storage is allocated, ensure that any other saved storages
+            # pointing to the same data all have the same dtype. If storage is
+            # not allocated, don't perform this check
+            if storage.data_ptr() != 0:
+                if storage.data_ptr() in self.storage_dtypes:
+                    if storage_dtype != self.storage_dtypes[storage.data_ptr()]:
+                        raise RuntimeError(
+                            "Cannot save multiple tensors or storages that "
+                            "view the same data as different types"
+                        )
+                else:
+                    self.storage_dtypes[storage.data_ptr()] = storage_dtype
+
+            storage_key = self.id_map.get(storage._cdata)
+            if storage_key is None:
+                storage_key = self.saver._write_storage_and_return_key(storage)
+                self.id_map[storage._cdata] = storage_key
+            location = torch.serialization.location_tag(storage)
+
+            return ("storage", storage_type, storage_key, location, storage_numel)
+
+        return None
+
+
+class incremental_save:
+    def __init__(self, name):
+        self.name = name
+        self.zipfile = torch._C.PyTorchFileWriter(str(name))
+        self.have_saved = False
+        self.next_key = 0
+
+    def __enter__(self):
+        return self
+
+    def store_early(self, tensor):
+        if isinstance(tensor, torch.Tensor):
+            return SavingProxyForTensor(tensor, self)
+        raise TypeError(f"can only store tensors early, not {type(tensor)}")
+
+    def save(self, obj):
+        if self.have_saved:
+            raise RuntimeError("have already saved")
+        # Write the pickle data for `obj`
+        data_buf = BytesIO()
+        pickler = IncrementalPyTorchPickler(self, data_buf, protocol=5)
+        pickler.dump(obj)
+        data_value = data_buf.getvalue()
+        self.zipfile.write_record("data.pkl", data_value, len(data_value))
+        self.have_saved = True
+
+    def _write_storage_and_return_key(self, storage):
+        if self.have_saved:
+            raise RuntimeError("have already saved")
+        key = self.next_key
+        self.next_key += 1
+        name = f"data/{key}"
+        if storage.device.type != "cpu":
+            storage = storage.cpu()
+        num_bytes = storage.nbytes()
+        self.zipfile.write_record(name, storage.data_ptr(), num_bytes)
+        return key
+
+    def __exit__(self, type, value, traceback):
+        self.zipfile.write_end_of_file()

--- a/lit_llama/utils.py
+++ b/lit_llama/utils.py
@@ -349,7 +349,7 @@ class SavingProxyForStorage:
         )
 
     def __reduce_ex__(self, protocol_version):
-        raise RuntimeError("this should be handled with out of band")
+        assert False, "this should be handled with out of band"
 
 
 class SavingProxyForTensor:
@@ -435,7 +435,7 @@ class incremental_save:
     def __init__(self, name):
         self.name = name
         self.zipfile = torch._C.PyTorchFileWriter(str(name))
-        self.have_saved = False
+        self.has_saved = False
         self.next_key = 0
 
     def __enter__(self):
@@ -447,7 +447,7 @@ class incremental_save:
         raise TypeError(f"can only store tensors early, not {type(tensor)}")
 
     def save(self, obj):
-        if self.have_saved:
+        if self.has_saved:
             raise RuntimeError("have already saved")
         # Write the pickle data for `obj`
         data_buf = BytesIO()
@@ -455,10 +455,10 @@ class incremental_save:
         pickler.dump(obj)
         data_value = data_buf.getvalue()
         self.zipfile.write_record("data.pkl", data_value, len(data_value))
-        self.have_saved = True
+        self.has_saved = True
 
     def _write_storage_and_return_key(self, storage):
-        if self.have_saved:
+        if self.has_saved:
             raise RuntimeError("have already saved")
         key = self.next_key
         self.next_key += 1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -47,6 +47,25 @@ def test_lazy_load_subclass(lit_llama):
                 torch.testing.assert_close(actual._load_tensor(), expected)
 
 
+def test_incremental_write(lit_llama):
+    import lit_llama.utils
+
+    sd = {str(k): torch.randn(5, 10) for k in range(3)}
+    sd_expected = {k: v.clone() for k, v in sd.items()}
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        path = pathlib.Path(tmpdirname)
+        fn = str(path / "test.pt")
+        with lit_llama.utils.incremental_save(fn) as f:
+            sd["0"] = f.store_early(sd["0"])
+            sd["2"] = f.store_early(sd["2"])
+            f.save(sd)
+        sd_actual = torch.load(fn)
+    assert sd_actual.keys() == sd_expected.keys()
+    for k, v_expected in sd_expected.items():
+        v_actual = sd_actual[k]
+        torch.testing.assert_close(v_expected, v_actual)
+
+
 def test_find_multiple(lit_llama):
     from lit_llama.utils import find_multiple
 


### PR DESCRIPTION
This makes convert hf checkpoint slower (for 30M to bfloat16 from 2:30 (two and a half minutes) to 3:45 on my machine, but max RSS size goes from 71.9GB to 1.6GB., allowing people with less RAM to convert checkpoints easily without swapping.
