### PR TITLE
Fix the multigate adapter fix for old and new checkpoint files

### DIFF
--- a/lit_llama/adapter.py
+++ b/lit_llama/adapter.py
@@ -119,7 +119,8 @@ class CausalSelfAttention(nn.Module):
             # in case we are loading with `utils.lazy_load()`
             tensor = tensor._load_tensor() if hasattr(tensor, "_load_tensor") else tensor
 
-            if tensor.shape[1] < 2: # For old checkpoints with unified gating value
+            if len(tensor.shape) < 4:
+                # For old checkpoints with unified gating value
                 state_dict[name] = tensor.reshape(1, 1, 1, 1).repeat(1, self.n_head, 1, 1)
             else:
                 state_dict[name] = tensor

--- a/lit_llama/adapter.py
+++ b/lit_llama/adapter.py
@@ -118,7 +118,12 @@ class CausalSelfAttention(nn.Module):
             tensor = state_dict[name]
             # in case we are loading with `utils.lazy_load()`
             tensor = tensor._load_tensor() if hasattr(tensor, "_load_tensor") else tensor
-            state_dict[name] = tensor.reshape(1, 1, 1, 1).repeat(1, self.n_head, 1, 1)
+
+            if tensor.shape[1] < 2: # For old checkpoints with unified gating value
+                state_dict[name] = tensor.reshape(1, 1, 1, 1).repeat(1, self.n_head, 1, 1)
+            else:
+                state_dict[name] = tensor
+
         return super()._load_from_state_dict(state_dict, prefix, *args, **kwargs)
 
 


### PR DESCRIPTION
I think this fix https://github.com/Lightning-AI/lit-llama/pull/297#issuecomment-1555976464 made the new multigating in the Adapter compatible with old checkpoint file, but it then broke the new checkpoint files via this dicussion here: https://github.com/Lightning-AI/lit-llama/commit/67c1e95176928ca149ebfcb016269a401fd3ba0b#commitcomment-115733970.

This PR hopefully fixes it for both new and old checkpoint files. What do you think @awaelchli ?