### PR TITLE
Fix undefined path on lora evaluation script

### DIFF
--- a/evaluate/lora.py
+++ b/evaluate/lora.py
@@ -96,7 +96,7 @@ def main(
     print("Loading model ...", file=sys.stderr)
     t0 = time.time()
 
-    with lazy_load(pretrained_path) as pretrained_checkpoint, lazy_load(lora_path) as lora_checkpoint:
+    with lazy_load(checkpoint_path) as pretrained_checkpoint, lazy_load(lora_path) as lora_checkpoint:
         name = llama_model_lookup(pretrained_checkpoint)
 
         with EmptyInitOnDevice(


### PR DESCRIPTION
There was an undefined / wrong path name in the evaluation script for Lora which caused the script to fail. This should fix it.