### PR TITLE
Add Loss Averaging and no_backward_sync() in Gradient Accumulation Logic

### DIFF
--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -131,9 +131,9 @@ def train(
         t0 = time.time()
 
         input_ids, targets = get_batch(fabric, train_data)
-        logits = model(input_ids)
-        loss = loss_fn(logits, targets)
         with fabric.no_backward_sync(model, enabled=((iter_num + 1) % gradient_accumulation_iters != 0)):
+            logits = model(input_ids)
+            loss = loss_fn(logits, targets)
             fabric.backward(loss / gradient_accumulation_iters)
 
         if (iter_num + 1) % gradient_accumulation_iters == 0:

--- a/finetune/adapter_v2.py
+++ b/finetune/adapter_v2.py
@@ -137,9 +137,9 @@ def train(
         t0 = time.time()
 
         input_ids, targets = get_batch(fabric, train_data)
-        logits = model(input_ids)
-        loss = loss_fn(logits, targets)
         with fabric.no_backward_sync(model, enabled=((iter_num + 1) % gradient_accumulation_iters != 0)):
+            logits = model(input_ids)
+            loss = loss_fn(logits, targets)
             fabric.backward(loss / gradient_accumulation_iters)
 
         if (iter_num + 1) % gradient_accumulation_iters == 0:

--- a/finetune/full.py
+++ b/finetune/full.py
@@ -114,12 +114,12 @@ def train(
                 param_group['lr'] = lr
 
         t0 = time.time()
-
+        
+        input_ids, targets = get_batch(fabric, train_data)
         with fabric.no_backward_sync(model, enabled=is_accumulating):
-            input_ids, targets = get_batch(fabric, train_data)
             logits = model(input_ids)
             loss = loss_fn(logits, targets)
-            fabric.backward(loss)
+            fabric.backward(loss / gradient_accumulation_iters)
 
         if not is_accumulating:
             optimizer.step()

--- a/finetune/lora.py
+++ b/finetune/lora.py
@@ -111,7 +111,7 @@ def train(
         with fabric.no_backward_sync(model, enabled=((iter_num + 1) % gradient_accumulation_iters != 0)):
             logits = model(input_ids)
             loss = loss_fn(logits, targets)
-            fabric.backward(loss / gradient_accumulation_iters )
+            fabric.backward(loss / gradient_accumulation_iters)
 
         if (iter_num + 1) % gradient_accumulation_iters == 0:
             optimizer.step()

--- a/finetune/lora.py
+++ b/finetune/lora.py
@@ -108,9 +108,10 @@ def train(
         t0 = time.time()
 
         input_ids, targets = get_batch(fabric, train_data)
-        logits = model(input_ids)
-        loss = loss_fn(logits, targets)
-        fabric.backward(loss)
+        with fabric.no_backward_sync(model, enabled=((iter_num + 1) % gradient_accumulation_iters != 0)):
+            logits = model(input_ids)
+            loss = loss_fn(logits, targets)
+            fabric.backward(loss / gradient_accumulation_iters )
 
         if (iter_num + 1) % gradient_accumulation_iters == 0:
             optimizer.step()


### PR DESCRIPTION
This fixes the gradient accumulation part in finetune directory.

I think averaging the loss is needed, based on the definition of gradient accumulation. 

Also, for efficiency in fine-tuning, I added no_backward_sync() where it wasn't.

I would appreciate any comments about this :)
