### PR TITLE
Integrate `Fabric.init_module(empty_weights=True)` into scripts

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -12,7 +12,7 @@ wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
 from lit_llama import LLaMA, Tokenizer
-from lit_llama.utils import EmptyInitOnDevice, lazy_load, llama_model_lookup
+from lit_llama.utils import EmptyInitOnDevice, lazy_load, llama_model_lookup, quantization
 
 
 @torch.no_grad()
@@ -126,9 +126,10 @@ def main(
     with lazy_load(checkpoint_path) as checkpoint:
         name = llama_model_lookup(checkpoint)
 
-        with EmptyInitOnDevice(
-                device=fabric.device, dtype=dtype, quantization_mode=quantize
-        ):
+        # with EmptyInitOnDevice(
+        #         device=fabric.device, dtype=dtype, quantization_mode=quantize
+        # ):
+        with fabric.init_module(empty_weights=True), quantization(quantize, enabled=(quantize is not None)):
             model = LLaMA.from_name(name)
 
         model.load_state_dict(checkpoint)

--- a/generate.py
+++ b/generate.py
@@ -132,7 +132,7 @@ def main(
     print(f"Time to load model: {time.time() - t0:.02f} seconds.", file=sys.stderr)
 
     model.eval()
-    model = fabric.setup_module(model)
+    model = fabric.setup(model)
 
     tokenizer = Tokenizer(tokenizer_path)
     encoded = tokenizer.encode(prompt, bos=True, eos=False, device=fabric.device)

--- a/generate.py
+++ b/generate.py
@@ -12,7 +12,7 @@ wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
 from lit_llama import LLaMA, Tokenizer
-from lit_llama.utils import EmptyInitOnDevice, lazy_load, llama_model_lookup, quantization
+from lit_llama.utils import lazy_load, llama_model_lookup, quantization
 
 
 @torch.no_grad()

--- a/generate.py
+++ b/generate.py
@@ -125,6 +125,7 @@ def main(
     t0 = time.time()
     with lazy_load(checkpoint_path) as checkpoint:
         name = llama_model_lookup(checkpoint)
+
         with fabric.init_module(empty_weights=True), quantization(mode=quantize):
             model = LLaMA.from_name(name)
 

--- a/generate/adapter.py
+++ b/generate/adapter.py
@@ -14,7 +14,7 @@ sys.path.append(str(wd))
 from generate import generate
 from lit_llama import Tokenizer
 from lit_llama.adapter import LLaMA
-from lit_llama.utils import EmptyInitOnDevice, lazy_load, llama_model_lookup
+from lit_llama.utils import lazy_load, llama_model_lookup, quantization
 from scripts.prepare_alpaca import generate_prompt
 
 
@@ -52,17 +52,15 @@ def main(
     assert pretrained_path.is_file()
     assert tokenizer_path.is_file()
 
-    fabric = L.Fabric(devices=1)
-    dtype = torch.bfloat16 if fabric.device.type == "cuda" and torch.cuda.is_bf16_supported() else torch.float32
+    precision = "bf16-true" if torch.cuda.is_available() and torch.cuda.is_bf16_supported() else "32-true"
+    fabric = L.Fabric(devices=1, precision=precision)
 
     print("Loading model ...", file=sys.stderr)
     t0 = time.time()
     with lazy_load(pretrained_path) as pretrained_checkpoint, lazy_load(adapter_path) as adapter_checkpoint:
         name = llama_model_lookup(pretrained_checkpoint)
 
-        with EmptyInitOnDevice(
-                device=fabric.device, dtype=dtype, quantization_mode=quantize
-        ):
+        with fabric.init_module(empty_weights=True), quantization(mode=quantize):
             model = LLaMA.from_name(name)
 
         # 1. Load the pretrained weights
@@ -73,7 +71,7 @@ def main(
     print(f"Time to load model: {time.time() - t0:.02f} seconds.", file=sys.stderr)
 
     model.eval()
-    model = fabric.setup_module(model)
+    model = fabric.setup(model)
 
     tokenizer = Tokenizer(tokenizer_path)
     sample = {"instruction": prompt, "input": input}

--- a/generate/adapter_v2.py
+++ b/generate/adapter_v2.py
@@ -14,7 +14,7 @@ sys.path.append(str(wd))
 from generate import generate
 from lit_llama import Tokenizer
 from lit_llama.adapter import LLaMA
-from lit_llama.utils import EmptyInitOnDevice, lazy_load, llama_model_lookup
+from lit_llama.utils import lazy_load, llama_model_lookup, quantization
 from lit_llama.adapter_v2 import add_adapter_v2_parameters_to_linear_layers
 from scripts.prepare_alpaca import generate_prompt
 
@@ -53,17 +53,15 @@ def main(
     assert pretrained_path.is_file()
     assert tokenizer_path.is_file()
 
-    fabric = L.Fabric(devices=1)
-    dtype = torch.bfloat16 if fabric.device.type == "cuda" and torch.cuda.is_bf16_supported() else torch.float32
+    precision = "bf16-true" if torch.cuda.is_available() and torch.cuda.is_bf16_supported() else "32-true"
+    fabric = L.Fabric(devices=1, precision=precision)
 
     print("Loading model ...", file=sys.stderr)
     t0 = time.time()
     with lazy_load(pretrained_path) as pretrained_checkpoint, lazy_load(adapter_path) as adapter_checkpoint:
         name = llama_model_lookup(pretrained_checkpoint)
 
-        with EmptyInitOnDevice(
-                device=fabric.device, dtype=dtype, quantization_mode=quantize
-        ):
+        with fabric.init_module(empty_weights=True), quantization(mode=quantize):
             model = LLaMA.from_name(name)
             add_adapter_v2_parameters_to_linear_layers(model)
 
@@ -75,7 +73,7 @@ def main(
     print(f"Time to load model: {time.time() - t0:.02f} seconds.", file=sys.stderr)
 
     model.eval()
-    model = fabric.setup_module(model)
+    model = fabric.setup(model)
 
     tokenizer = Tokenizer(tokenizer_path)
     sample = {"instruction": prompt, "input": input}

--- a/generate/full.py
+++ b/generate/full.py
@@ -65,7 +65,7 @@ def main(
     print(f"Time to load model: {time.time() - t0:.02f} seconds.", file=sys.stderr)
 
     model.eval()
-    model = fabric.setup_module(model)
+    model = fabric.setup(model)
 
     tokenizer = Tokenizer(tokenizer_path)
     sample = {"instruction": prompt, "input": input}

--- a/generate/full.py
+++ b/generate/full.py
@@ -12,7 +12,7 @@ wd = Path(__file__).absolute().parent.parent
 sys.path.append(str(wd))
 
 from lit_llama import LLaMA, Tokenizer
-from lit_llama.utils import EmptyInitOnDevice
+from lit_llama.utils import quantization
 from scripts.prepare_alpaca import generate_prompt
 from generate import generate
 
@@ -50,14 +50,13 @@ def main(
     assert checkpoint_path.is_file(), checkpoint_path
     assert tokenizer_path.is_file(), tokenizer_path
 
-    fabric = L.Fabric(devices=1)
-    dtype = torch.bfloat16 if fabric.device.type == "cuda" and torch.cuda.is_bf16_supported() else torch.float32
+    precision = "bf16-true" if torch.cuda.is_available() and torch.cuda.is_bf16_supported() else "32-true"
+    fabric = L.Fabric(devices=1, precision=precision)
 
     print("Loading model ...", file=sys.stderr)
     t0 = time.time()
-    with EmptyInitOnDevice(
-        device=fabric.device, dtype=dtype, quantization_mode=quantize
-    ):
+    
+    with fabric.init_module(empty_weights=True), quantization(mode=quantize):
         model = LLaMA.from_name(model_size)
 
     checkpoint = torch.load(checkpoint_path)

--- a/generate/lora.py
+++ b/generate/lora.py
@@ -48,7 +48,6 @@ def main(
         quantize: Whether to quantize the model and using which method:
             ``"llm.int8"``: LLM.int8() mode,
             ``"gptq.int4"``: GPTQ 4-bit mode.
-        dtype: The dtype to use during generation.
         max_new_tokens: The number of generation steps to take.
         top_k: The number of top most probable tokens to consider in the sampling process.
         temperature: A value controlling the randomness of the sampling process. Higher values result in more random
@@ -63,11 +62,6 @@ def main(
 
     precision = "bf16-true" if torch.cuda.is_available() and torch.cuda.is_bf16_supported() else "32-true"
     fabric = L.Fabric(devices=1, precision=precision)
-
-    dt = getattr(torch, dtype, None)
-    if not isinstance(dt, torch.dtype):
-        raise ValueError(f"{dtype} is not a valid dtype.")
-    dtype = dt
 
     print("Loading model ...", file=sys.stderr)
     t0 = time.time()

--- a/generate/lora.py
+++ b/generate/lora.py
@@ -14,7 +14,7 @@ sys.path.append(str(wd))
 from generate import generate
 from lit_llama import Tokenizer, LLaMA
 from lit_llama.lora import lora
-from lit_llama.utils import EmptyInitOnDevice, lazy_load, llama_model_lookup
+from lit_llama.utils import lazy_load, llama_model_lookup
 from scripts.prepare_alpaca import generate_prompt
 
 lora_r = 8
@@ -29,7 +29,6 @@ def main(
     pretrained_path: Path = Path("checkpoints/lit-llama/7B/lit-llama.pth"),
     tokenizer_path: Path = Path("checkpoints/lit-llama/tokenizer.model"),
     quantize: Optional[str] = None,
-    dtype: str = "float32",
     max_new_tokens: int = 100,
     top_k: int = 200,
     temperature: float = 0.8,

--- a/generate/lora.py
+++ b/generate/lora.py
@@ -87,7 +87,7 @@ def main(
     print(f"Time to load model: {time.time() - t0:.02f} seconds.", file=sys.stderr)
 
     model.eval()
-    model = fabric.setup_module(model)
+    model = fabric.setup(model)
 
     tokenizer = Tokenizer(tokenizer_path)
     sample = {"instruction": prompt, "input": input}

--- a/lit_llama/utils.py
+++ b/lit_llama/utils.py
@@ -135,11 +135,6 @@ class EmptyInitOnDevice(torch.overrides.TorchFunctionMode):
         return func(*args, **kwargs)
 
 
-
-
-        # if device.type != "cuda":
-        #     raise ValueError("Quantization is only supported on the GPU.")
-
 @contextmanager
 def quantization(mode: str = None):
     quantized_linear_cls = None
@@ -154,7 +149,7 @@ def quantization(mode: str = None):
         quantized_linear_cls = functools.partial(ColBlockQuantizedLinear, bits=8, tile_cols=-1)
     elif mode is not None:
         raise ValueError(f"Unknown quantization mode: {mode}")
-    
+
     enabled = mode is not None
     torch_linear_cls = torch.nn.Linear
     if enabled:

--- a/lit_llama/utils.py
+++ b/lit_llama/utils.py
@@ -141,7 +141,7 @@ class EmptyInitOnDevice(torch.overrides.TorchFunctionMode):
         #     raise ValueError("Quantization is only supported on the GPU.")
 
 @contextmanager
-def quantization(mode: str, enabled: bool = True):
+def quantization(mode: str = None):
     quantized_linear_cls = None
     if mode == 'llm.int8':
         from .quantization import Linear8bitLt
@@ -152,9 +152,10 @@ def quantization(mode: str, enabled: bool = True):
     elif mode == 'gptq.int8':
         from .quantization import ColBlockQuantizedLinear
         quantized_linear_cls = functools.partial(ColBlockQuantizedLinear, bits=8, tile_cols=-1)
-    else:
+    elif mode is not None:
         raise ValueError(f"Unknown quantization mode: {mode}")
-
+    
+    enabled = mode is not None
     torch_linear_cls = torch.nn.Linear
     if enabled:
         torch.nn.Linear = quantized_linear_cls


### PR DESCRIPTION
Advertizes the use of the `init_module` context manager with empty weight initialization. This is a draft for now and requires https://github.com/Lightning-AI/lightning/pull/17627. I created this in advance to validate the PR in Lightning and to showcase the usage. 

We can decide to keep the EmptyInitOnDevice in utils for posterity and backward compatibility, but its functionality is now absorbed into `Fabric.init_module()`. 