### PR TITLE
Sparsegpt

### DIFF
--- a/lit_llama/sparsification.py
+++ b/lit_llama/sparsification.py
@@ -19,7 +19,7 @@ class SparseGPT:
             prunen=0,
             prunem=0,
             blocksize=128,
-            percdamp=.01,
+            percdamp=0.01,
 
     ):
         assert isinstance(linear_module, torch.nn.Linear)
@@ -30,101 +30,99 @@ class SparseGPT:
         self.columns = linear_module.weight.shape[1]
         self.H = torch.zeros((self.columns, self.columns), device=self.dev)
         self.nsamples = 0
-        self.block_size = blocksize
+        self.blocksize = blocksize
         self.sparsity = sparsity
-        self.perdamp = percdamp
+        self.percdamp = percdamp
         self.prunen = prunen
         self.prunem = prunem
 
-        def collect_input_stats(self, _1, inp, _2):
-            inp = inp[0].detach()
-            self.last_inp = inp
-            if len(inp.shape) == 2:
-                inp = inp.unsqueeze(0)
-            tmp = inp.shape[0]
-            if len(inp.shape) == 3:
-                inp = inp.reshape((-1, inp.shape[-1]))
-            inp = inp.t()
-            self.H *= self.nsamples / (self.nsamples + tmp)
-            self.nsamples += tmp
-            inp = math.sqrt(2 / self.nsamples) * inp.float()
-            self.H += inp.matmul(inp.t())
+    def collect_input_stats(self, _1, inp, _2):
+        inp = inp[0].detach()
+        self.last_inp = inp
+        if len(inp.shape) == 2:
+            inp = inp.unsqueeze(0)
+        tmp = inp.shape[0]
+        if len(inp.shape) == 3:
+            inp = inp.reshape((-1, inp.shape[-1]))
+        inp = inp.t()
+        self.H *= self.nsamples / (self.nsamples + tmp)
+        self.nsamples += tmp
+        inp = math.sqrt(2 / self.nsamples) * inp.float()
+        self.H += inp.matmul(inp.t())
 
-        def sparsify(self):
-            W = self.linear_module.weight.detach().to(dtype=torch.float, copy=True)
+    def sparsify(self):
 
-            H = self.H
-            del self.H
-            dead = torch.diag(H) == 0
-            H[dead, dead] = 1
-            W[:, dead] = 0
+        W = self.linear_module.weight.detach().to(dtype=torch.float, copy=True)
+        H = self.H
+        del self.H
+        dead = torch.diag(H) == 0
+        H[dead, dead] = 1
+        W[:, dead] = 0
+
+        Losses = torch.zeros_like(W)
+        Q = torch.zeros_like(W)
+
+        damp = self.percdamp * torch.mean(torch.diag(H))
+        diag = torch.arange(self.columns, device=self.dev)
+        H[diag, diag] += damp
+        H = torch.linalg.cholesky(H)
+        H = torch.cholesky_inverse(H)
+        H = torch.linalg.cholesky(H, upper=True)
+        Hinv = H
+
+        mask = None
+
+        for i1 in range(0, self.columns, self.blocksize):
+            i2 = min(i1 + self.blocksize, self.columns)
+            count = i2 - i1
+
+            W1 = W[:, i1:i2].clone()
+            Q1 = torch.zeros_like(W1)
+            Err1 = torch.zeros_like(W1)
+            Losses1 = torch.zeros_like(W1)
+            Hinv1 = Hinv[i1:i2, i1:i2]
 
 
-            Losses = torch.zeros_like(W)
-            Q = torch.zeros_like(W)
-
-            damp = self.percdamp * torch.mean(torch.diag(H))
-            diag = torch.arange(self.columns, device=self.dev)
-            H[diag, diag] += damp
-            H = torch.linalg.cholesky(H)
-            H = torch.cholesky_inverse(H)
-            H = torch.linalg.cholesky(H, upper=True)
-            Hinv = H
-
-            mask = None
-
-            for i1 in range(0, self.columns, self.blocksize):
-                i2 = min(i1 + self.blocksize, self.columns)
-                count = i2 - i1
-
-                W1 = W[:, i1:i2].clone()
-                Q1 = torch.zeros_like(W1)
-                Err1 = torch.zeros_like(W1)
-                Losses1 = torch.zeros_like(W1)
-                Hinv1 = Hinv[i1:i2, i1:i2]
-
-
-                if prunen == 0: 
-                    if mask is not None:
-                        mask1 = mask[:, i1:i2]
-                    else:
-                        tmp = W1 ** 2 / (torch.diag(Hinv1).reshape((1, -1))) ** 2
-                        thresh = torch.sort(tmp.flatten())[0][int(tmp.numel() * sparsity)]
-                        mask1 = tmp <= thresh
+            if self.prunen == 0: 
+                if mask is not None:
+                    mask1 = mask[:, i1:i2]
                 else:
-                    mask1 = torch.zeros_like(W1) == 1
+                    tmp = W1 ** 2 / (torch.diag(Hinv1).reshape((1, -1))) ** 2
+                    thresh = torch.sort(tmp.flatten())[0][int(tmp.numel() * self.sparsity)]
+                    mask1 = tmp <= thresh
+            else:
+                mask1 = torch.zeros_like(W1) == 1
 
-                for i in range(count):
-                    w = W1[:, i]
-                    d = Hinv1[i, i]
+            for i in range(count):
+                w = W1[:, i]
+                d = Hinv1[i, i]
 
-                    if prunen != 0 and i % prunem == 0:
-                        tmp = W1[:, i:(i + prunem)] ** 2 / (torch.diag(Hinv1)[i:(i + prunem)].reshape((1, -1))) ** 2
-                        mask1.scatter_(1, i + torch.topk(tmp, prunen, dim=1, largest=False)[1], True)
+                if self.prunen != 0 and i % self.prunem == 0:
+                    tmp = W1[:, i:(i + self.prunem)] ** 2 / (torch.diag(Hinv1)[i:(i + self.prunem)].reshape((1, -1))) ** 2
+                    mask1.scatter_(1, i + torch.topk(tmp, self.prunen, dim=1, largest=False)[1], True)
 
-                    q = w.clone()
-                    q[mask1[:, i]] = 0
+                q = w.clone()
+                q[mask1[:, i]] = 0
 
 
-                    Q1[:, i] = q
-                    Losses1[:, i] = (w - q) ** 2 / d ** 2
+                Q1[:, i] = q
+                Losses1[:, i] = (w - q) ** 2 / d ** 2
 
-                    err1 = (w - q) / d
-                    W1[:, i:] -= err1.unsqueeze(1).matmul(Hinv1[i, i:].unsqueeze(0))
-                    Err1[:, i] = err1
-           
-                Q[:, i1:i2] = Q1
-                Losses += torch.sum(Losses1, 1) / 2
+                err1 = (w - q) / d
+                W1[:, i:] -= err1.unsqueeze(1).matmul(Hinv1[i, i:].unsqueeze(0))
+                Err1[:, i] = err1
+        
+            Q[:, i1:i2] = Q1
+            Losses[:, i1:i2] = Losses1 / 2
 
-                W[:, i2:] -= Err1.matmul(Hinv[i1:i2, i2:])
+            W[:, i2:] -= Err1.matmul(Hinv[i1:i2, i2:])
 
-            pruned_weights = Q.reshape(self.linear_module.weight.shape).to(
-                          self.linear_module.weight.data.dtype
-            )
-
-            self.linear_module.weight.data = pruned_weights
-            del pruned_weights
-            error = torch.sum(Losses).item()
-
-            return error
+        pruned_weights = Q.reshape(self.linear_module.weight.shape).to(
+                        self.linear_module.weight.data.dtype
+        )
+        
+        # set the linear module weights to pruned weights
+        self.linear_module.weight.data = pruned_weights
+        error = torch.sum(Losses).item()
+        return error
 

--- a/sparsify/sparsegpt.py
+++ b/sparsify/sparsegpt.py
@@ -12,7 +12,6 @@ from typing import Optional
 import torch
 from datasets import load_dataset
 
-
 wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
@@ -41,7 +40,7 @@ def llama_blockwise_sparsification(
     sample_inputs, 
     working_device,
     *,
-    sparsity=0,
+    sparsity,
     prunen=0,
     prunem=0,
     
@@ -87,8 +86,8 @@ def llama_blockwise_sparsification(
                 prunen=prunen,
                 prunem=prunem,
             )
-            
-            handle = model.lm_head.register_forward_hook(sparsegpt.collect_input_stats)
+
+            handle = module.register_forward_hook(sparsegpt.collect_input_stats)
            
             for j in range(inps.size(0)):
                 outs[j : j + 1], _ = block(
@@ -100,6 +99,9 @@ def llama_blockwise_sparsification(
 
             handle.remove()
 
+            
+            print("sparsifying", end=" ")
+            sys.stdout.flush()
             error = sparsegpt.sparsify()
 
             del sparsegpt
@@ -155,7 +157,7 @@ def main(
     tokenizer_path: Path = Path("checkpoints/lit-llama/tokenizer.model"),
     n_samples: int = 128,
     dtype: str = "float32",
-    sparsity: int = 0,
+    sparsity: float = 0.1,
     prunem: int = 0,
     prunen: int = 0
 ) -> None:


### PR DESCRIPTION
This is the sparseGPT code based on IST-DASLab project.

I followed the same coding principles as used in the lit-llama gptq code.

I created a file called sparsification which is the algorithm for SparseGPT and a folder called sparsify/sparsegpt.py to run the algorithm on the model in the checkpoint_path.

This is my first contribution to the project, If I missed some household admin I apologize in advance.

Assuming you have a  model under checkpoints/open-llama/7B

you can run this command:
python sparsify/sparsegpt.py --checkpoint_path checkpoints/lit-llama/7B/lit-llama.pth

Key Notes:

0. I used half n_samples (128-->64) due to memory requirement

1. The SparseGPT paper was evaluated on models trained not using the chinchilla scaling law (Therefore my hypothesis is that some of the weights of those models were not useful, hence they were able to prune 50%). With Llama I only used 0.1 target sparsity.)

2. The source code of SparseGPT consists of a quantization algorithm similar to GPTQ, however, I removed this code because we already have GPTQ in the lit-llama source code. If you would like me to include it, it is also okay I can include GPTQ under the sparseGPT code.

Before you commit, please also test from your side, and let me know if you want me to solve any bug or integrate a specific feature

Thanks