### PR TITLE
Change variable name

### DIFF
--- a/evaluate/adapter.py
+++ b/evaluate/adapter.py
@@ -118,7 +118,7 @@ def main(
         test_string = load_eval_data(dsname)
 
         if instruction_tuning:
-            sample = {"instruction": test_string, "input": input}
+            sample = {"instruction": test_string, "input": ""}
             test_string = generate_prompt(sample)
 
         encoded_text = tokenizer.encode(

--- a/evaluate/adapter_v2.py
+++ b/evaluate/adapter_v2.py
@@ -114,7 +114,7 @@ def main(
     for dsname in datasets.split(","):
         test_string = load_eval_data(dsname)
 
-        sample = {"instruction": test_string, "input": input}
+        sample = {"instruction": test_string, "input": ""}
         test_string = generate_prompt(sample)
 
         encoded_text = tokenizer.encode(

--- a/evaluate/lora.py
+++ b/evaluate/lora.py
@@ -125,7 +125,7 @@ def main(
         test_string = load_eval_data(dsname)
 
         if instruction_tuning:
-            sample = {"instruction": test_string, "input": input}
+            sample = {"instruction": test_string, "input": ""}
             test_string = generate_prompt(sample)
         
         encoded_text = tokenizer.encode(

--- a/generate/adapter.py
+++ b/generate/adapter.py
@@ -20,7 +20,7 @@ from scripts.prepare_alpaca import generate_prompt
 
 def main(
     prompt: str = "What food do lamas eat?",
-    input: str = "",
+    input_sentence: str = "",
     adapter_path: Path = Path("out/adapter/alpaca/lit-llama-adapter-finetuned.pth"),
     pretrained_path: Path = Path("checkpoints/lit-llama/7B/lit-llama.pth"),
     tokenizer_path: Path = Path("checkpoints/lit-llama/tokenizer.model"),
@@ -29,7 +29,7 @@ def main(
     top_k: int = 200,
     temperature: float = 0.8,
 ) -> None:
-    """Generates a response based on a given instruction and an optional input.
+    """Generates a response based on a given instruction and an optional input_sentence.
     This script will only work with checkpoints from the instruction-tuned LLaMA-Adapter model.
     See `finetune_adapter.py`.
 
@@ -37,7 +37,7 @@ def main(
         prompt: The prompt/instruction (Alpaca style).
         adapter_path: Path to the checkpoint with trained adapter weights, which are the output of
             `finetune_adapter.py`.
-        input: Optional input (Alpaca style).
+        input_sentence: Optional input_sentence (Alpaca style).
         pretrained_path: The path to the checkpoint with pretrained LLaMA weights.
         tokenizer_path: The tokenizer path to load.
         quantize: Whether to quantize the model and using which method:
@@ -74,7 +74,7 @@ def main(
     model = fabric.setup(model)
 
     tokenizer = Tokenizer(tokenizer_path)
-    sample = {"instruction": prompt, "input": input}
+    sample = {"instruction": prompt, "input": input_sentence}
     prompt = generate_prompt(sample)
     encoded = tokenizer.encode(prompt, bos=True, eos=False, device=model.device)
     prompt_length = encoded.size(0)

--- a/generate/adapter_v2.py
+++ b/generate/adapter_v2.py
@@ -21,7 +21,7 @@ from scripts.prepare_alpaca import generate_prompt
 
 def main(
     prompt: str = "What food do lamas eat?",
-    input: str = "",
+    input_sentence: str = "",
     adapter_path: Path = Path("out/adapter_v2/alpaca/lit-llama-adapter-finetuned.pth"),
     pretrained_path: Path = Path("checkpoints/lit-llama/7B/lit-llama.pth"),
     tokenizer_path: Path = Path("checkpoints/lit-llama/tokenizer.model"),
@@ -30,7 +30,7 @@ def main(
     top_k: int = 200,
     temperature: float = 0.8,
 ) -> None:
-    """Generates a response based on a given instruction and an optional input.
+    """Generates a response based on a given instruction and an optional input_sentence.
     This script will only work with checkpoints from the instruction-tuned LLaMA-Adapter model.
     See `finetune_adapter_v2.py`.
 
@@ -38,7 +38,7 @@ def main(
         prompt: The prompt/instruction (Alpaca style).
         adapter_path: Path to the checkpoint with trained adapter weights, which are the output of
             `finetune_adapter_v2.py`.
-        input: Optional input (Alpaca style).
+        input_sentence: Optional input_sentence (Alpaca style).
         pretrained_path: The path to the checkpoint with pretrained LLaMA weights.
         tokenizer_path: The tokenizer path to load.
         quantize: Whether to quantize the model and using which method:
@@ -76,7 +76,7 @@ def main(
     model = fabric.setup(model)
 
     tokenizer = Tokenizer(tokenizer_path)
-    sample = {"instruction": prompt, "input": input}
+    sample = {"instruction": prompt, "input": input_sentence}
     prompt = generate_prompt(sample)
     encoded = tokenizer.encode(prompt, bos=True, eos=False, device=model.device)
     prompt_length = encoded.size(0)

--- a/generate/full.py
+++ b/generate/full.py
@@ -67,7 +67,7 @@ def main(
     model = fabric.setup(model)
 
     tokenizer = Tokenizer(tokenizer_path)
-    sample = {"instruction": prompt, "input": input}
+    sample = {"instruction": prompt, "input": ""}
     prompt = generate_prompt(sample)
     encoded = tokenizer.encode(prompt, bos=True, eos=False, device=fabric.device)
     prompt_length = encoded.size(0)

--- a/generate/lora.py
+++ b/generate/lora.py
@@ -24,7 +24,7 @@ lora_dropout = 0.05
 
 def main(
     prompt: str = "What food do lamas eat?",
-    input: str = "",
+    input_sentence: str = "",
     lora_path: Path = Path("out/lora/alpaca/lit-llama-lora-finetuned.pth"),
     pretrained_path: Path = Path("checkpoints/lit-llama/7B/lit-llama.pth"),
     tokenizer_path: Path = Path("checkpoints/lit-llama/tokenizer.model"),
@@ -33,7 +33,7 @@ def main(
     top_k: int = 200,
     temperature: float = 0.8,
 ) -> None:
-    """Generates a response based on a given instruction and an optional input.
+    """Generates a response based on a given instruction and an optional input_sentence.
     This script will only work with checkpoints from the instruction-tuned LoRA model.
     See `finetune_lora.py`.
 
@@ -41,7 +41,7 @@ def main(
         prompt: The prompt/instruction (Alpaca style).
         lora_path: Path to the checkpoint with trained LoRA weights, which are the output of
             `finetune_lora.py`.
-        input: Optional input (Alpaca style).
+        input_sentence: Optional input_sentence (Alpaca style).
         pretrained_path: The path to the checkpoint with pretrained LLaMA weights.
         tokenizer_path: The tokenizer path to load.
         quantize: Whether to quantize the model and using which method:
@@ -82,7 +82,7 @@ def main(
     model = fabric.setup(model)
 
     tokenizer = Tokenizer(tokenizer_path)
-    sample = {"instruction": prompt, "input": input}
+    sample = {"instruction": prompt, "input": input_sentence}
     prompt = generate_prompt(sample)
     encoded = tokenizer.encode(prompt, bos=True, eos=False, device=model.device)
 


### PR DESCRIPTION
In Python, `input` is a *built-in function*. As far as I am concerned, using another name would be more appropriate.

- For `generate/*`, there is no difference between the two versions.
- For `evaluate/*`, the previous version uses the string `<built-in function input>` as the input, which is quite weird. Although we can execute these files successfully, an empty string may be better here.

Thank you.
