### PR TITLE
Check torch and lightning versions before running models

### DIFF
--- a/datasets
+++ b/datasets
@@ -1,1 +1,0 @@
-/data/shared/datasets/

--- a/datasets
+++ b/datasets
@@ -1,0 +1,1 @@
+/data/shared/datasets/

--- a/evaluate/adapter.py
+++ b/evaluate/adapter.py
@@ -16,7 +16,7 @@ sys.path.append(str(wd))
 
 from lit_llama import Tokenizer
 from lit_llama.adapter import LLaMA
-from lit_llama.utils import EmptyInitOnDevice, lazy_load, llama_model_lookup
+from lit_llama.utils import EmptyInitOnDevice, lazy_load, llama_model_lookup, check_python_packages
 from scripts.prepare_alpaca import generate_prompt
 
 from datasets import load_dataset
@@ -79,6 +79,8 @@ def main(
     assert adapter_path.is_file()
     assert checkpoint_path.is_file()
     assert tokenizer_path.is_file()
+
+    check_python_packages()
 
     fabric = L.Fabric(accelerator=accelerator, devices=1)
 

--- a/evaluate/adapter.py
+++ b/evaluate/adapter.py
@@ -16,7 +16,7 @@ sys.path.append(str(wd))
 
 from lit_llama import Tokenizer
 from lit_llama.adapter import LLaMA
-from lit_llama.utils import EmptyInitOnDevice, lazy_load, llama_model_lookup, check_python_packages
+from lit_llama.utils import EmptyInitOnDevice, lazy_load, llama_model_lookup, _check_python_packages
 from scripts.prepare_alpaca import generate_prompt
 
 from datasets import load_dataset
@@ -80,7 +80,7 @@ def main(
     assert checkpoint_path.is_file()
     assert tokenizer_path.is_file()
 
-    check_python_packages()
+    _check_python_packages()
 
     fabric = L.Fabric(accelerator=accelerator, devices=1)
 

--- a/evaluate/adapter_v2.py
+++ b/evaluate/adapter_v2.py
@@ -16,7 +16,7 @@ sys.path.append(str(wd))
 
 from lit_llama import Tokenizer
 from lit_llama.adapter import LLaMA
-from lit_llama.utils import EmptyInitOnDevice, lazy_load, llama_model_lookup, check_python_packages
+from lit_llama.utils import EmptyInitOnDevice, lazy_load, llama_model_lookup, _check_python_packages
 from lit_llama.adapter_v2 import add_adapter_v2_parameters_to_linear_layers
 from scripts.prepare_alpaca import generate_prompt
 
@@ -76,7 +76,7 @@ def main(
     assert checkpoint_path.is_file()
     assert tokenizer_path.is_file()
 
-    check_python_packages()
+    _check_python_packages()
 
     fabric = L.Fabric(accelerator=accelerator, devices=1)
 

--- a/evaluate/adapter_v2.py
+++ b/evaluate/adapter_v2.py
@@ -16,7 +16,7 @@ sys.path.append(str(wd))
 
 from lit_llama import Tokenizer
 from lit_llama.adapter import LLaMA
-from lit_llama.utils import EmptyInitOnDevice, lazy_load, llama_model_lookup
+from lit_llama.utils import EmptyInitOnDevice, lazy_load, llama_model_lookup, check_python_packages
 from lit_llama.adapter_v2 import add_adapter_v2_parameters_to_linear_layers
 from scripts.prepare_alpaca import generate_prompt
 
@@ -75,6 +75,8 @@ def main(
     assert adapter_path.is_file()
     assert checkpoint_path.is_file()
     assert tokenizer_path.is_file()
+
+    check_python_packages()
 
     fabric = L.Fabric(accelerator=accelerator, devices=1)
 

--- a/evaluate/full.py
+++ b/evaluate/full.py
@@ -15,7 +15,7 @@ wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
 from lit_llama import LLaMA, Tokenizer
-from lit_llama.utils import EmptyInitOnDevice
+from lit_llama.utils import EmptyInitOnDevice, check_python_packages
 
 from datasets import load_dataset
 
@@ -73,6 +73,8 @@ def main(
         checkpoint_path = Path(f"checkpoints/lit-llama/{model_size}/lit-llama.pth")
     assert checkpoint_path.is_file()
     assert tokenizer_path.is_file()
+
+    check_python_packages()
 
     fabric = L.Fabric(accelerator=accelerator, devices=1)
 

--- a/evaluate/full.py
+++ b/evaluate/full.py
@@ -15,7 +15,7 @@ wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
 from lit_llama import LLaMA, Tokenizer
-from lit_llama.utils import EmptyInitOnDevice, check_python_packages
+from lit_llama.utils import EmptyInitOnDevice, _check_python_packages
 
 from datasets import load_dataset
 
@@ -74,7 +74,7 @@ def main(
     assert checkpoint_path.is_file()
     assert tokenizer_path.is_file()
 
-    check_python_packages()
+    _check_python_packages()
 
     fabric = L.Fabric(accelerator=accelerator, devices=1)
 

--- a/evaluate/lora.py
+++ b/evaluate/lora.py
@@ -15,7 +15,7 @@ wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
 from lit_llama import LLaMA, Tokenizer
-from lit_llama.utils import EmptyInitOnDevice, lazy_load, llama_model_lookup
+from lit_llama.utils import EmptyInitOnDevice, lazy_load, llama_model_lookup, check_python_packages
 from lit_llama.lora import lora
 from scripts.prepare_alpaca import generate_prompt
 
@@ -82,6 +82,8 @@ def main(
     assert lora_path.is_file()
     assert checkpoint_path.is_file()
     assert tokenizer_path.is_file()
+
+    check_python_packages()
 
     if quantize is not None:
         raise NotImplementedError("Quantization in LoRA is not supported yet")

--- a/evaluate/lora.py
+++ b/evaluate/lora.py
@@ -15,7 +15,7 @@ wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
 from lit_llama import LLaMA, Tokenizer
-from lit_llama.utils import EmptyInitOnDevice, lazy_load, llama_model_lookup, check_python_packages
+from lit_llama.utils import EmptyInitOnDevice, lazy_load, llama_model_lookup, _check_python_packages
 from lit_llama.lora import lora
 from scripts.prepare_alpaca import generate_prompt
 
@@ -83,7 +83,7 @@ def main(
     assert checkpoint_path.is_file()
     assert tokenizer_path.is_file()
 
-    check_python_packages()
+    _check_python_packages()
 
     if quantize is not None:
         raise NotImplementedError("Quantization in LoRA is not supported yet")

--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -28,6 +28,7 @@ sys.path.append(str(wd))
 from generate import generate
 from lit_llama.adapter import LLaMA, LLaMAConfig, mark_only_adapter_as_trainable, adapter_state_from_state_dict
 from lit_llama.tokenizer import Tokenizer
+from lit_llama.utils import check_python_packages
 from scripts.prepare_alpaca import generate_prompt
 from lightning.fabric.strategies import DeepSpeedStrategy
 
@@ -64,6 +65,8 @@ def main(
     pretrained_path: str = "checkpoints/lit-llama/7B/lit-llama.pth",
     out_dir: str = "out/adapter/alpaca",
 ):
+
+    check_python_packages()
 
     fabric = L.Fabric(
         accelerator="cuda", 

--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -28,7 +28,7 @@ sys.path.append(str(wd))
 from generate import generate
 from lit_llama.adapter import LLaMA, LLaMAConfig, mark_only_adapter_as_trainable, adapter_state_from_state_dict
 from lit_llama.tokenizer import Tokenizer
-from lit_llama.utils import check_python_packages
+from lit_llama.utils import _check_python_packages
 from scripts.prepare_alpaca import generate_prompt
 from lightning.fabric.strategies import DeepSpeedStrategy
 
@@ -66,7 +66,7 @@ def main(
     out_dir: str = "out/adapter/alpaca",
 ):
 
-    check_python_packages()
+    _check_python_packages()
 
     fabric = L.Fabric(
         accelerator="cuda", 

--- a/finetune/adapter_v2.py
+++ b/finetune/adapter_v2.py
@@ -36,7 +36,7 @@ from lit_llama.adapter_v2 import (
 from lit_llama.tokenizer import Tokenizer
 from scripts.prepare_alpaca import generate_prompt
 from lightning.fabric.strategies import DeepSpeedStrategy
-from lit_llama.utils import check_python_packages
+from lit_llama.utils import _check_python_packages
 
 eval_interval = 600
 save_interval = 1000
@@ -70,7 +70,7 @@ def main(
     out_dir: str = "out/adapter_v2/alpaca",
 ):
     
-    check_python_packages()
+    _check_python_packages()
 
     fabric = L.Fabric(
         accelerator="cuda",

--- a/finetune/adapter_v2.py
+++ b/finetune/adapter_v2.py
@@ -36,7 +36,7 @@ from lit_llama.adapter_v2 import (
 from lit_llama.tokenizer import Tokenizer
 from scripts.prepare_alpaca import generate_prompt
 from lightning.fabric.strategies import DeepSpeedStrategy
-
+from lit_llama.utils import check_python_packages
 
 eval_interval = 600
 save_interval = 1000
@@ -69,6 +69,8 @@ def main(
     pretrained_path: str = "checkpoints/lit-llama/7B/lit-llama.pth",
     out_dir: str = "out/adapter_v2/alpaca",
 ):
+    
+    check_python_packages()
 
     fabric = L.Fabric(
         accelerator="cuda",

--- a/finetune/full.py
+++ b/finetune/full.py
@@ -23,7 +23,7 @@ sys.path.append(str(wd))
 from generate import generate
 from lit_llama.model import Block, LLaMA, LLaMAConfig
 from lit_llama.tokenizer import Tokenizer
-from lit_llama.utils import save_model_checkpoint, check_python_packages
+from lit_llama.utils import save_model_checkpoint, _check_python_packages
 from scripts.prepare_alpaca import generate_prompt
 
 
@@ -54,7 +54,7 @@ def main(
     out_dir: str = "out/full/alpaca",
 ):
 
-    check_python_packages()
+    _check_python_packages()
 
     auto_wrap_policy = partial(transformer_auto_wrap_policy, transformer_layer_cls={Block})
     strategy = FSDPStrategy(auto_wrap_policy=auto_wrap_policy, activation_checkpointing=Block, limit_all_gathers=True)

--- a/finetune/full.py
+++ b/finetune/full.py
@@ -23,7 +23,7 @@ sys.path.append(str(wd))
 from generate import generate
 from lit_llama.model import Block, LLaMA, LLaMAConfig
 from lit_llama.tokenizer import Tokenizer
-from lit_llama.utils import save_model_checkpoint
+from lit_llama.utils import save_model_checkpoint, check_python_packages
 from scripts.prepare_alpaca import generate_prompt
 
 
@@ -53,6 +53,8 @@ def main(
     pretrained_path: str = "checkpoints/lit-llama/7B/lit-llama.pth",
     out_dir: str = "out/full/alpaca",
 ):
+
+    check_python_packages()
 
     auto_wrap_policy = partial(transformer_auto_wrap_policy, transformer_layer_cls={Block})
     strategy = FSDPStrategy(auto_wrap_policy=auto_wrap_policy, activation_checkpointing=Block, limit_all_gathers=True)

--- a/finetune/lora.py
+++ b/finetune/lora.py
@@ -21,6 +21,7 @@ from generate import generate
 from lit_llama.lora import mark_only_lora_as_trainable, lora, lora_state_dict
 from lit_llama.model import LLaMA, LLaMAConfig
 from lit_llama.tokenizer import Tokenizer
+from lit_llama.utils import check_python_packages
 from scripts.prepare_alpaca import generate_prompt
 
 
@@ -51,6 +52,8 @@ def main(
     tokenizer_path: str = "checkpoints/lit-llama/tokenizer.model",
     out_dir: str = "out/lora/alpaca",
 ):
+    
+    check_python_packages()
 
     fabric = L.Fabric(accelerator="cuda", devices=1, precision="bf16-true")
     fabric.launch()
@@ -70,7 +73,7 @@ def main(
         model = LLaMA(config)
         # strict=False because missing keys due to LoRA weights not contained in checkpoint state
         model.load_state_dict(checkpoint, strict=False)
-    
+
     mark_only_lora_as_trainable(model)
 
     optimizer = torch.optim.AdamW(model.parameters(), lr=learning_rate)

--- a/finetune/lora.py
+++ b/finetune/lora.py
@@ -21,7 +21,7 @@ from generate import generate
 from lit_llama.lora import mark_only_lora_as_trainable, lora, lora_state_dict
 from lit_llama.model import LLaMA, LLaMAConfig
 from lit_llama.tokenizer import Tokenizer
-from lit_llama.utils import check_python_packages
+from lit_llama.utils import _check_python_packages
 from scripts.prepare_alpaca import generate_prompt
 
 
@@ -53,7 +53,7 @@ def main(
     out_dir: str = "out/lora/alpaca",
 ):
     
-    check_python_packages()
+    _check_python_packages()
 
     fabric = L.Fabric(accelerator="cuda", devices=1, precision="bf16-true")
     fabric.launch()

--- a/generate/adapter.py
+++ b/generate/adapter.py
@@ -14,7 +14,7 @@ sys.path.append(str(wd))
 from generate import generate
 from lit_llama import Tokenizer
 from lit_llama.adapter import LLaMA
-from lit_llama.utils import lazy_load, llama_model_lookup, quantization
+from lit_llama.utils import lazy_load, llama_model_lookup, quantization, check_python_packages
 from scripts.prepare_alpaca import generate_prompt
 
 
@@ -51,6 +51,8 @@ def main(
     assert adapter_path.is_file()
     assert pretrained_path.is_file()
     assert tokenizer_path.is_file()
+
+    check_python_packages()
 
     precision = "bf16-true" if torch.cuda.is_available() and torch.cuda.is_bf16_supported() else "32-true"
     fabric = L.Fabric(devices=1, precision=precision)

--- a/generate/adapter.py
+++ b/generate/adapter.py
@@ -14,7 +14,7 @@ sys.path.append(str(wd))
 from generate import generate
 from lit_llama import Tokenizer
 from lit_llama.adapter import LLaMA
-from lit_llama.utils import lazy_load, llama_model_lookup, quantization, check_python_packages
+from lit_llama.utils import lazy_load, llama_model_lookup, quantization, _check_python_packages
 from scripts.prepare_alpaca import generate_prompt
 
 
@@ -52,7 +52,7 @@ def main(
     assert pretrained_path.is_file()
     assert tokenizer_path.is_file()
 
-    check_python_packages()
+    _check_python_packages()
 
     precision = "bf16-true" if torch.cuda.is_available() and torch.cuda.is_bf16_supported() else "32-true"
     fabric = L.Fabric(devices=1, precision=precision)

--- a/generate/adapter_v2.py
+++ b/generate/adapter_v2.py
@@ -14,7 +14,7 @@ sys.path.append(str(wd))
 from generate import generate
 from lit_llama import Tokenizer
 from lit_llama.adapter import LLaMA
-from lit_llama.utils import lazy_load, llama_model_lookup, quantization
+from lit_llama.utils import lazy_load, llama_model_lookup, quantization, check_python_packages
 from lit_llama.adapter_v2 import add_adapter_v2_parameters_to_linear_layers
 from scripts.prepare_alpaca import generate_prompt
 
@@ -52,6 +52,8 @@ def main(
     assert adapter_path.is_file()
     assert pretrained_path.is_file()
     assert tokenizer_path.is_file()
+
+    check_python_packages()
 
     precision = "bf16-true" if torch.cuda.is_available() and torch.cuda.is_bf16_supported() else "32-true"
     fabric = L.Fabric(devices=1, precision=precision)

--- a/generate/adapter_v2.py
+++ b/generate/adapter_v2.py
@@ -14,7 +14,7 @@ sys.path.append(str(wd))
 from generate import generate
 from lit_llama import Tokenizer
 from lit_llama.adapter import LLaMA
-from lit_llama.utils import lazy_load, llama_model_lookup, quantization, check_python_packages
+from lit_llama.utils import lazy_load, llama_model_lookup, quantization, _check_python_packages
 from lit_llama.adapter_v2 import add_adapter_v2_parameters_to_linear_layers
 from scripts.prepare_alpaca import generate_prompt
 
@@ -53,7 +53,7 @@ def main(
     assert pretrained_path.is_file()
     assert tokenizer_path.is_file()
 
-    check_python_packages()
+    _check_python_packages()
 
     precision = "bf16-true" if torch.cuda.is_available() and torch.cuda.is_bf16_supported() else "32-true"
     fabric = L.Fabric(devices=1, precision=precision)

--- a/generate/full.py
+++ b/generate/full.py
@@ -12,7 +12,7 @@ wd = Path(__file__).absolute().parent.parent
 sys.path.append(str(wd))
 
 from lit_llama import LLaMA, Tokenizer
-from lit_llama.utils import quantization, check_python_packages
+from lit_llama.utils import quantization, _check_python_packages
 from scripts.prepare_alpaca import generate_prompt
 from generate import generate
 
@@ -50,7 +50,7 @@ def main(
     assert checkpoint_path.is_file(), checkpoint_path
     assert tokenizer_path.is_file(), tokenizer_path
 
-    check_python_packages()
+    _check_python_packages()
 
     precision = "bf16-true" if torch.cuda.is_available() and torch.cuda.is_bf16_supported() else "32-true"
     fabric = L.Fabric(devices=1, precision=precision)

--- a/generate/full.py
+++ b/generate/full.py
@@ -12,7 +12,7 @@ wd = Path(__file__).absolute().parent.parent
 sys.path.append(str(wd))
 
 from lit_llama import LLaMA, Tokenizer
-from lit_llama.utils import quantization
+from lit_llama.utils import quantization, check_python_packages
 from scripts.prepare_alpaca import generate_prompt
 from generate import generate
 
@@ -49,6 +49,8 @@ def main(
         checkpoint_path = Path(f"checkpoints/lit-llama/{model_size}/lit-llama.pth")
     assert checkpoint_path.is_file(), checkpoint_path
     assert tokenizer_path.is_file(), tokenizer_path
+
+    check_python_packages()
 
     precision = "bf16-true" if torch.cuda.is_available() and torch.cuda.is_bf16_supported() else "32-true"
     fabric = L.Fabric(devices=1, precision=precision)

--- a/generate/lora.py
+++ b/generate/lora.py
@@ -14,7 +14,7 @@ sys.path.append(str(wd))
 from generate import generate
 from lit_llama import Tokenizer, LLaMA
 from lit_llama.lora import lora
-from lit_llama.utils import lazy_load, llama_model_lookup, check_python_packages
+from lit_llama.utils import lazy_load, llama_model_lookup, _check_python_packages
 from scripts.prepare_alpaca import generate_prompt
 
 lora_r = 8
@@ -59,7 +59,7 @@ def main(
     if quantize is not None:
         raise NotImplementedError("Quantization in LoRA is not supported yet")
     
-    check_python_packages()
+    _check_python_packages()
 
     precision = "bf16-true" if torch.cuda.is_available() and torch.cuda.is_bf16_supported() else "32-true"
     fabric = L.Fabric(devices=1, precision=precision)

--- a/generate/lora.py
+++ b/generate/lora.py
@@ -14,7 +14,7 @@ sys.path.append(str(wd))
 from generate import generate
 from lit_llama import Tokenizer, LLaMA
 from lit_llama.lora import lora
-from lit_llama.utils import lazy_load, llama_model_lookup
+from lit_llama.utils import lazy_load, llama_model_lookup, check_python_packages
 from scripts.prepare_alpaca import generate_prompt
 
 lora_r = 8
@@ -58,6 +58,8 @@ def main(
 
     if quantize is not None:
         raise NotImplementedError("Quantization in LoRA is not supported yet")
+    
+    check_python_packages()
 
     precision = "bf16-true" if torch.cuda.is_available() and torch.cuda.is_bf16_supported() else "32-true"
     fabric = L.Fabric(devices=1, precision=precision)

--- a/lit_llama/utils.py
+++ b/lit_llama/utils.py
@@ -520,23 +520,7 @@ def get_packages(pkgs):
 
 def check_python_packages():
 
-    d = {
-        'torch': '2.0.0',
-        'lightning': '2.1.0.dev0',
-    }
-
-    versions = get_packages(d.keys())
-
-    wrong_package_triggered = False
-    for (pkg_name, suggested_ver), actual_ver in zip(d.items(), versions):
-        if actual_ver == 'N/A':
-            continue
-        actual_ver, suggested_ver = version_parse(actual_ver), version_parse(suggested_ver)
-        if actual_ver < suggested_ver:
-            print(f'[FAIL] {pkg_name} {actual_ver}, please upgrade to {suggested_ver}')
-            wrong_package_triggered = True
-        else:
-            print(f'[OK] {pkg_name} {actual_ver}')
-
-    if wrong_package_triggered:
+    torch_ = RequirementCache('torch>=2.0.0')
+    lit_ = RequirementCache('lightning>=2.1.0')
+    if not bool(torch_) or not bool(lit_):
         raise ImportError("Wrong package version(s) installed.")

--- a/lit_llama/utils.py
+++ b/lit_llama/utils.py
@@ -499,7 +499,7 @@ class incremental_save:
 
 
 
-def check_python_packages():
+def _check_python_packages():
 
     torch_ = RequirementCache('torch>=2.0.0')
     lit_ = RequirementCache('lightning>=2.1.0')

--- a/lit_llama/utils.py
+++ b/lit_llama/utils.py
@@ -497,25 +497,6 @@ class incremental_save:
         self.zipfile.write_end_of_file()
 
 
-def get_packages(pkgs):
-    versions = []
-    for p in pkgs:
-        try:
-            imported = __import__(p)
-            try:
-                versions.append(imported.__version__)
-            except AttributeError:
-                try:
-                    versions.append(imported.version)
-                except AttributeError:
-                    try:
-                        versions.append(imported.version_info)
-                    except AttributeError:
-                        versions.append('0.0')
-        except ImportError:
-            print(f'[FAIL]: {p} is not installed and/or cannot be imported.')
-            versions.append('N/A')
-    return versions
 
 
 def check_python_packages():

--- a/lit_llama/utils.py
+++ b/lit_llama/utils.py
@@ -5,6 +5,7 @@ import pickle
 import warnings
 from io import BytesIO
 from pathlib import Path
+from packaging.version import parse as version_parse
 from contextlib import contextmanager
 
 import torch
@@ -494,3 +495,48 @@ class incremental_save:
 
     def __exit__(self, type, value, traceback):
         self.zipfile.write_end_of_file()
+
+
+def get_packages(pkgs):
+    versions = []
+    for p in pkgs:
+        try:
+            imported = __import__(p)
+            try:
+                versions.append(imported.__version__)
+            except AttributeError:
+                try:
+                    versions.append(imported.version)
+                except AttributeError:
+                    try:
+                        versions.append(imported.version_info)
+                    except AttributeError:
+                        versions.append('0.0')
+        except ImportError:
+            print(f'[FAIL]: {p} is not installed and/or cannot be imported.')
+            versions.append('N/A')
+    return versions
+
+
+def check_python_packages():
+
+    d = {
+        'torch': '2.0.0',
+        'lightning': '2.1.0.dev0',
+    }
+
+    versions = get_packages(d.keys())
+
+    wrong_package_triggered = False
+    for (pkg_name, suggested_ver), actual_ver in zip(d.items(), versions):
+        if actual_ver == 'N/A':
+            continue
+        actual_ver, suggested_ver = version_parse(actual_ver), version_parse(suggested_ver)
+        if actual_ver < suggested_ver:
+            print(f'[FAIL] {pkg_name} {actual_ver}, please upgrade to {suggested_ver}')
+            wrong_package_triggered = True
+        else:
+            print(f'[OK] {pkg_name} {actual_ver}')
+
+    if wrong_package_triggered:
+        raise ImportError("Wrong package version(s) installed.")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -57,7 +57,7 @@ def test_incremental_write(tmp_path, lit_llama):
         sd["0"] = f.store_early(sd["0"])
         sd["2"] = f.store_early(sd["2"])
         f.save(sd)
-    sd_actual = torch.load(fn, weights_only=True)
+    sd_actual = torch.load(fn, weights_only=False)
     assert sd_actual.keys() == sd_expected.keys()
     for k, v_expected in sd_expected.items():
         v_actual = sd_actual[k]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -57,7 +57,7 @@ def test_incremental_write(tmp_path, lit_llama):
         sd["0"] = f.store_early(sd["0"])
         sd["2"] = f.store_early(sd["2"])
         f.save(sd)
-    sd_actual = torch.load(fn)
+    sd_actual = torch.load(fn, weights_only=True)
     assert sd_actual.keys() == sd_expected.keys()
     for k, v_expected in sd_expected.items():
         v_actual = sd_actual[k]


### PR DESCRIPTION
I think that a lot of weird errors with uninformative error messages that users encounter (e.g., see #438) are due to package mismatches. Since we are using the latest features from torch and Fabric, code kind of runs but then there's this weird error here and there, or even a missing feature.

So, I propose only allowing to run the scripts if the minimal versions are installed. If a user doesn't have these required PyTorch and Lightning versions, there is a message informing the user about that.