### PR TITLE
Fix: Variable name

### DIFF
--- a/lit_llama/utils.py
+++ b/lit_llama/utils.py
@@ -28,7 +28,7 @@ def llama_model_lookup(checkpoint: dict) -> str:
     
     Checks the width of the lm_head.weight matrix, as these uniquely identify the model.
     """
-    embedding_size = checkpoint['transformer.wte.weight'].shape[1]
+    embedding_size = checkpoint['lm_head.weight'].shape[1]
     return llama_model_sizes[embedding_size]
 
 


### PR DESCRIPTION
Hello.

I think variable's name should be changed in 'lit_llama/utils.py.'

When I implement your code, the existing code causes error. Then I debugged with printing. 

There was no key named 'transformer.wte.weight' in checkpoint.

Thank you.