### PR TITLE
Add license at the top of files

### DIFF
--- a/evaluate/adapter.py
+++ b/evaluate/adapter.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 # This mimics GPTQ's evaluation metrics: https://github.com/IST-DASLab/gptq/
 # Thanks to E. Frantar et al GPTQ: Accurate Post-training Compression for GPT, arXiv:2210.17323
 import math

--- a/evaluate/adapter_v2.py
+++ b/evaluate/adapter_v2.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 # This mimics GPTQ's evaluation metrics: https://github.com/IST-DASLab/gptq/
 # Thanks to E. Frantar et al GPTQ: Accurate Post-training Compression for GPT, arXiv:2210.17323
 import math

--- a/evaluate/full.py
+++ b/evaluate/full.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 # This mimics GPTQ's evaluation metrics: https://github.com/IST-DASLab/gptq/
 # Thanks to E. Frantar et al GPTQ: Accurate Post-training Compression for GPT, arXiv:2210.17323
 import math

--- a/evaluate/lora.py
+++ b/evaluate/lora.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 # This mimics GPTQ's evaluation metrics: https://github.com/IST-DASLab/gptq/
 # Thanks to E. Frantar et al GPTQ: Accurate Post-training Compression for GPT, arXiv:2210.17323
 import math

--- a/finetune/adapter.py
+++ b/finetune/adapter.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 """
 Instruction-tuning with LLaMA-Adapter on the Alpaca dataset following the paper
 

--- a/finetune/adapter_v2.py
+++ b/finetune/adapter_v2.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 """
 Instruction-tuning with LLaMA-Adapter v2 on the Alpaca dataset following the paper
 

--- a/finetune/full.py
+++ b/finetune/full.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 """
 Instruction-tuning on the Alpaca dataset using a regular finetuning procedure (updating all layers).
 

--- a/finetune/lora.py
+++ b/finetune/lora.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 """
 Instruction-tuning with LoRA on the Alpaca dataset.
 

--- a/generate.py
+++ b/generate.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import sys
 import time
 import warnings

--- a/generate/adapter.py
+++ b/generate/adapter.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import sys
 import time
 import warnings

--- a/generate/adapter_v2.py
+++ b/generate/adapter_v2.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import sys
 import time
 import warnings

--- a/generate/full.py
+++ b/generate/full.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import sys
 import time
 import warnings

--- a/generate/lora.py
+++ b/generate/lora.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import sys
 import time
 import warnings

--- a/lit_llama/__init__.py
+++ b/lit_llama/__init__.py
@@ -1,2 +1,4 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 from lit_llama.model import LLaMAConfig, LLaMA, RMSNorm, build_rope_cache, apply_rope
 from lit_llama.tokenizer import Tokenizer

--- a/lit_llama/adapter.py
+++ b/lit_llama/adapter.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 """Implementation of the paper:
 
 LLaMA-Adapter: Efficient Fine-tuning of Language Models with Zero-init Attention

--- a/lit_llama/adapter_v2.py
+++ b/lit_llama/adapter_v2.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import torch
 from torch import Tensor
 import torch.nn as nn

--- a/lit_llama/lora.py
+++ b/lit_llama/lora.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 # Derived from https://github.com/microsoft/LoRA
 #  ------------------------------------------------------------------------------------------
 #  Copyright (c) Microsoft Corporation. All rights reserved.

--- a/lit_llama/model.py
+++ b/lit_llama/model.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 """Full definition of a LLaMA Language Model, all of it in this single file.
 
 Based on the nanoGPT implementation: https://github.com/karpathy/nanoGPT.

--- a/lit_llama/packed_dataset.py
+++ b/lit_llama/packed_dataset.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 # Very loosely inspired by indexed_dataset in Fairseq, Megatron
 # https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/data/indexed_dataset.py
 

--- a/lit_llama/quantization.py
+++ b/lit_llama/quantization.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import os
 from contextlib import contextmanager
 import warnings

--- a/lit_llama/tokenizer.py
+++ b/lit_llama/tokenizer.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import os
 from pathlib import Path
 from typing import Optional

--- a/lit_llama/utils.py
+++ b/lit_llama/utils.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 """Utility functions for training and inference."""
 
 import functools

--- a/pretrain/redpajama.py
+++ b/pretrain/redpajama.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import os
 import sys
 import math

--- a/pretrain/shakespeare.py
+++ b/pretrain/shakespeare.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 """
 This script is a placeholder for training LLaMA from scratch.
 Currently, it just trains on the Shakespeare dataset.

--- a/quantize/gptq.py
+++ b/quantize/gptq.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 # This adapts GPTQ's quantization process: https://github.com/IST-DASLab/gptq/
 # E. Frantar et al GPTQ: Accurate Post-training Compression for GPT, arXiv:2210.17323
 # portions copyright by the authors licensed under the Apache License 2.0

--- a/scripts/convert_checkpoint.py
+++ b/scripts/convert_checkpoint.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import gc
 import shutil
 from pathlib import Path

--- a/scripts/convert_hf_checkpoint.py
+++ b/scripts/convert_hf_checkpoint.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import collections
 import contextlib
 import gc

--- a/scripts/convert_lora_weights.py
+++ b/scripts/convert_lora_weights.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import sys
 import time
 from pathlib import Path

--- a/scripts/download.py
+++ b/scripts/download.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import os
 from typing import Optional
 from urllib.request import urlretrieve

--- a/scripts/prepare_alpaca.py
+++ b/scripts/prepare_alpaca.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 """Implementation derived from https://github.com/tloen/alpaca-lora"""
 import sys
 from pathlib import Path

--- a/scripts/prepare_any_text.py
+++ b/scripts/prepare_any_text.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 """Implementation derived from https://github.com/tloen/alpaca-lora"""
 import sys
 from pathlib import Path

--- a/scripts/prepare_dolly.py
+++ b/scripts/prepare_dolly.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 """Implementation derived from https://github.com/tloen/alpaca-lora"""
 import sys
 from pathlib import Path

--- a/scripts/prepare_redpajama.py
+++ b/scripts/prepare_redpajama.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import json
 import glob
 import os

--- a/scripts/prepare_shakespeare.py
+++ b/scripts/prepare_shakespeare.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 # MIT License
 
 # Copyright (c) 2022 Andrej Karpathy

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import os
 
 from setuptools import setup, find_packages

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import sys
 from pathlib import Path
 

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 from dataclasses import asdict
 import pytest
 import sys

--- a/tests/test_adapter_v2.py
+++ b/tests/test_adapter_v2.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import pytest
 import sys
 

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import functools
 import subprocess
 import sys

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import torch
 
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import torch
 import pytest
 import sys

--- a/tests/test_packed_dataset.py
+++ b/tests/test_packed_dataset.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import os
 from unittest.mock import MagicMock
 import requests

--- a/tests/test_prepare_redpajama.py
+++ b/tests/test_prepare_redpajama.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import json
 import os
 import subprocess

--- a/tests/test_prepare_shakespeare.py
+++ b/tests/test_prepare_shakespeare.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import os
 import subprocess
 import sys

--- a/tests/test_rmsnorm.py
+++ b/tests/test_rmsnorm.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import torch
 
 

--- a/tests/test_rope.py
+++ b/tests/test_rope.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import torch
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,5 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
 import tempfile
 import pathlib
 


### PR DESCRIPTION
lit-llama is being used in other projects, often vendored (individual files taken out and reused).

This is not a bad thing per se, but we need to make sure the license and authorship are clear when this happens.

This PR adds licenses at the top of every file, just like we do for PyTorch Lightning and Fabric.